### PR TITLE
Feature/add name to user

### DIFF
--- a/Backend/Domain.Models/Entities/ApplicationUser.cs
+++ b/Backend/Domain.Models/Entities/ApplicationUser.cs
@@ -4,6 +4,8 @@ namespace Domain.Models.Entities;
 
 public class ApplicationUser : IdentityUser
 {
+    public string FullName { get; set; } = null!;
+
     public string? RefreshToken { get; set; }
     public DateTime RefreshTokenExpireTime { get; set; }
 

--- a/Backend/LMS.API/Services/Seed/UserSeeder.cs
+++ b/Backend/LMS.API/Services/Seed/UserSeeder.cs
@@ -43,21 +43,24 @@ public class UserSeeder(
 
     private async Task AddDemoUsersAsync()
     {
-        await AddUserToDb("teacher@test.com", TeacherRole);
-        await AddUserToDb("student@test.com", StudentRole);
+        await AddUserToDb("Teacher", "teacher@test.com", TeacherRole);
+        await AddUserToDb("Student", "student@test.com", StudentRole);
     }
 
     private async Task AddUsersAsync(int nrOfUsers)
     {
-        var faker = new Faker("sv");
+        var students = new Faker<ApplicationUser>("sv")
+            .RuleFor(u => u.Email, f => f.Person.Email)
+            .RuleFor(u => u.FullName, f => f.Person.FullName)
+            .Generate(nrOfUsers);
+
         for (int i = 0; i < nrOfUsers; i++)
         {
-            var email = faker.Internet.Email();
-            await AddUserToDb(email, StudentRole);
+            await AddUserToDb(students[i].FullName, students[i].Email!, StudentRole);
         }
     }
 
-    private async Task AddUserToDb(string email, string role)
+    private async Task AddUserToDb(string name, string email, string role)
     {
         var existing = await userManager.FindByEmailAsync(email);
         if (existing != null) return;
@@ -65,7 +68,7 @@ public class UserSeeder(
         var passWord = configuration["password"];
         ArgumentNullException.ThrowIfNull(passWord, nameof(passWord));
 
-        var user = new ApplicationUser { UserName = email, Email = email };
+        var user = new ApplicationUser { UserName = email, Email = email, FullName = name };
 
         var result = await userManager.CreateAsync(user, passWord);
         if (!result.Succeeded) throw new Exception(string.Join("\n", result.Errors));

--- a/Backend/LMS.Infractructure/Data/Configurations/ApplicationUserConfigurations.cs
+++ b/Backend/LMS.Infractructure/Data/Configurations/ApplicationUserConfigurations.cs
@@ -10,5 +10,9 @@ public class ApplicationUserConfigurations : IEntityTypeConfiguration<Applicatio
     {
         builder.ToTable("ApplicationUser");
         //Add more configurations here
+
+        builder.Property(c => c.FullName)
+            .IsRequired()
+            .HasMaxLength(200);
     }
 }

--- a/Backend/LMS.Infractructure/Migrations/20250919124638_AddFullnameToApplicationUser.Designer.cs
+++ b/Backend/LMS.Infractructure/Migrations/20250919124638_AddFullnameToApplicationUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LMS.Infractructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LMS.Infractructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250919124638_AddFullnameToApplicationUser")]
+    partial class AddFullnameToApplicationUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Backend/LMS.Infractructure/Migrations/20250919124638_AddFullnameToApplicationUser.cs
+++ b/Backend/LMS.Infractructure/Migrations/20250919124638_AddFullnameToApplicationUser.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LMS.Infractructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFullnameToApplicationUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "FullName",
+                table: "ApplicationUser",
+                type: "TEXT",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FullName",
+                table: "ApplicationUser");
+        }
+    }
+}

--- a/Backend/LMS.Services/AuthService.cs
+++ b/Backend/LMS.Services/AuthService.cs
@@ -81,8 +81,10 @@ public class AuthService : IAuthService
 
         var claims = new List<Claim>()
         {
-            new Claim(ClaimTypes.Name, user.UserName!),
-            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString())
+            new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new Claim(JwtRegisteredClaimNames.Name, user.UserName!),
+            new Claim(JwtRegisteredClaimNames.Profile, user.FullName),
+            new Claim(JwtRegisteredClaimNames.Email, user.Email!),
             //Add more if needed
         };
 
@@ -90,7 +92,7 @@ public class AuthService : IAuthService
 
         foreach (var role in roles)
         {
-            claims.Add(new Claim(ClaimTypes.Role, role));
+            claims.Add(new Claim("role", role));
         }
 
         return claims;

--- a/Frontend/src/utilities/token/decodeToken.ts
+++ b/Frontend/src/utilities/token/decodeToken.ts
@@ -1,9 +1,10 @@
 import { jwtDecode } from 'jwt-decode';
 
 type JwtPayload = {
-  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'?: string;
-  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier'?: string;
-  'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'?: string;
+  profile: string;
+  name: string;
+  sub: string;
+  role: string;
   exp?: number;
 };
 
@@ -12,9 +13,9 @@ const decodeToken = (token: string) => {
 
   const claims = jwtDecode<JwtPayload>(token);
 
-  const name = claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'] ?? 'unknown';
-  const id = claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier'] ?? 'unknown';
-  const role = claims['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'] ?? 'none';
+  const name = claims.profile ?? 'unknown';
+  const id = claims.sub ?? 'unknown';
+  const role = claims.role ?? 'none';
 
   return { name, id, role };
 };


### PR DESCRIPTION
**Reason for change**
Add a `FullName` field to the `User` table so that users can be identified by a proper name instead of only `username/email`.

**Changes**

- Added `Fullname` field to `User` entity and database table
- Updated seeding to include user names
- Added `Fullname` to JWT claims
- Changed claim names to shorter and more readable ones
- Update `decodeToken` function in frontend to match the new claim names

**How to test**

1. Drop the database (mac: `dotnet ef database drop --project LMS.Infractructure --startup-project LMS.API`)
2. Run migrations to update database (mac: `dotnet ef database update --project LMS.Infractructure --startup-project LMS.API`)
3. Start backend and frontend projects
4. Log in with a seeded user
5. Verify that the user’s full name is displayed in the navbar
