### PR TITLE
Feature/frontend create wrapper component for buttons #110

### DIFF
--- a/Frontend/src/components/Button.tsx
+++ b/Frontend/src/components/Button.tsx
@@ -1,0 +1,19 @@
+import { ReactElement } from 'react';
+
+import { Button as MuiButton } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+interface IButtonProps {
+  icon?: boolean;
+  text: string;
+  onClick: () => void;
+}
+
+const Button = ({ text, icon = true, onClick }: IButtonProps): ReactElement => {
+  return (
+    <MuiButton variant="contained" onClick={onClick} startIcon={icon && <AddIcon />}>
+      {text}
+    </MuiButton>
+  );
+};
+
+export default Button;

--- a/Frontend/src/components/Button.tsx
+++ b/Frontend/src/components/Button.tsx
@@ -8,7 +8,7 @@ interface IButtonProps {
   onClick: () => void;
 }
 
-const Button = ({ text, icon = true, onClick }: IButtonProps): ReactElement => {
+const Button = ({ text, icon = false, onClick }: IButtonProps): ReactElement => {
   return (
     <MuiButton variant="contained" onClick={onClick} startIcon={icon && <AddIcon />}>
       {text}

--- a/Frontend/src/components/ButtonCard.tsx
+++ b/Frontend/src/components/ButtonCard.tsx
@@ -1,0 +1,26 @@
+import Card from './Card';
+import Button from './Button';
+import { Stack } from '@mui/material';
+
+interface IButtonConfig {
+  text: string;
+  onClick: () => void;
+}
+
+interface IButtonCardProps {
+  buttons: IButtonConfig[];
+}
+
+const ButtonCard = ({ buttons }: IButtonCardProps) => {
+  return (
+    <Card title="Snabblänkar">
+      <Stack spacing={1}>
+        {buttons.map((btn) => (
+          <Button key={btn.text} text={btn.text} onClick={btn.onClick} />
+        ))}
+      </Stack>
+    </Card>
+  );
+};
+
+export default ButtonCard;

--- a/Frontend/src/pages/Sandbox.tsx
+++ b/Frontend/src/pages/Sandbox.tsx
@@ -1,7 +1,29 @@
+import { useNavigate } from 'react-router';
+import ButtonCard from '../components/ButtonCard';
 import Main from '../components/Main';
 
 const Sandbox = () => {
-  return <Main>Nothing to look at</Main>;
+  // Demo for <ButtonCard />
+  // Doc: The <ButtonCard /> is a reusable card component that renders a list of buttons
+  // with their own labels and click handlers. Useful for creating quick actions / shortcuts panels
+  // like “Snabblänkar” "Kursadministration".
+  const navigate = useNavigate();
+  const handlerOnClickUser = () => {
+    navigate('/admin/users');
+  };
+  const handlerOnClickCourse = () => {
+    navigate('/admin/courses');
+  };
+  return (
+    <Main>
+      <ButtonCard
+        buttons={[
+          { text: 'Hantera användare', onClick: handlerOnClickUser },
+          { text: 'Hantera kurser', onClick: handlerOnClickCourse },
+        ]}
+      />
+    </Main>
+  );
 };
 
 export default Sandbox;


### PR DESCRIPTION
**Reason for change**
Created wrapper components for buttons to make them reusable and consistent across the app.

Briefly describe the feature or bug fix that this PR implements.
**Changes**

- Added Button component with optional icon support, reusable for a single button.
- Added ButtonCard component, reusable inside Teacher Dashboard and Kursadministration.

**How to test**

1. Checkout this branch.
2. Navigate to /sandbox page and verify <ButtonCard /> is rendered.
3. Test the Button component with and without an icon by setting the icon to true or false.