### PR TITLE
Feature/frontend activity api integration

### DIFF
--- a/Frontend/src/pages/CoursePage.tsx
+++ b/Frontend/src/pages/CoursePage.tsx
@@ -44,7 +44,7 @@ const CoursePage = (): ReactElement => {
                         start: formatDate(module.startDate),
                         end: formatDate(module.endDate),
                       }}
-                      link={`modules/${module.id}`}
+                      link={`/courses/${resolvedCourse.id}/modules/${module.id}`}
                     />
                   ));
                 }}

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -8,6 +8,7 @@ import { dashboardLoader } from '../utilities/loaders/dashboardLoader';
 import CoursePage from '../pages/CoursePage';
 import { courseLoader, defaultCourseLoader } from '../utilities/loaders/courseLoader';
 import CourseListBoard from '../components/CourseListBoard';
+import { moduleLoader } from '../utilities/loaders/moduleLoader';
 
 export const router = createBrowserRouter([
   {
@@ -37,6 +38,13 @@ export const router = createBrowserRouter([
         path: 'courses/:id',
         element: <CoursePage />,
         loader: courseLoader,
+        children: [
+          {
+            path: 'modules/:moduleId',
+            // element: <ModulePage />, // TODO: to be implemented later
+            loader: moduleLoader,
+          },
+        ],
       },
       {
         path: 'course',

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -38,18 +38,17 @@ export const router = createBrowserRouter([
         path: 'courses/:id',
         element: <CoursePage />,
         loader: courseLoader,
-        children: [
-          {
-            path: 'modules/:moduleId',
-            // element: <ModulePage />, // TODO: to be implemented later
-            loader: moduleLoader,
-          },
-        ],
+        children: [],
       },
       {
         path: 'course',
         element: <div />,
         loader: defaultCourseLoader,
+      },
+      {
+        path: 'courses/:courseId/modules/:moduleId',
+        // element: < ModulePage />, // TODO: to be implemented later
+        loader: moduleLoader,
       },
     ],
   },

--- a/Frontend/src/utilities/loaders/moduleLoader.ts
+++ b/Frontend/src/utilities/loaders/moduleLoader.ts
@@ -1,0 +1,15 @@
+import { LoaderFunctionArgs } from 'react-router';
+import { fetchWithToken } from '../api/fetchWithToken';
+import { BASE_URL } from '../constants';
+import { IActivity, IModule, IModuleLoader } from '../types';
+
+export const moduleLoader = async ({ params }: LoaderFunctionArgs): Promise<IModuleLoader> => {
+  if (!params.moduleId) {
+    throw new Response('Module ID is required', { status: 400 });
+  }
+
+  return {
+    module: fetchWithToken<IModule>(`${BASE_URL}/modules/${params.moduleId}`),
+    activities: fetchWithToken<IActivity[]>(`${BASE_URL}/modules/${params.moduleId}/activities`),
+  };
+};

--- a/Frontend/src/utilities/types.ts
+++ b/Frontend/src/utilities/types.ts
@@ -51,9 +51,28 @@ export interface IModule {
   description: string;
   startDate: string;
   endDate: string;
+  activities: IActivity[];
 }
-
 export interface ICourseLoader {
   course: Promise<ICourse>;
   participants: Promise<IParticipant[]>;
+}
+
+export interface IActivityType {
+  id: string;
+  name: string;
+}
+
+export interface IActivity {
+  id: string;
+  name: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  activityType: IActivityType;
+}
+
+export interface IModuleLoader {
+  module: Promise<IModule>;
+  activities: Promise<IActivity[]>;
 }


### PR DESCRIPTION
**Reason for change**

Prepare frontend routing and data loading for module activities. We need a dedicated route and loader for modules so that later we can display activities per module.

**Changes**

- Added new route courses/:courseId/modules/:moduleId in router configuration.
- Created moduleLoader to fetch module details and activities from API:
     - GET /api/modules/{moduleId}
     - GET /api/modules/{moduleId}/activities
- Tested loader temporarily in Sandbox component.
- Updated EntityCard link in CoursePage to navigate correctly to module route.

**How to test**

1. Start frontend and login with any seeded user (student or teacher).
2. Go to /courses → click on a course.
3. On the course page, click on any module.
4. The URL should update to /courses/{courseId}/modules/{moduleId}.
5. No design or final page is implemented in this PR. This only sets up routing and loader for future tasks.
