### PR TITLE
Feature/module page

### DIFF
--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -14,7 +14,7 @@ public class MapperProfile : Profile
     {
         CreateMap<UserRegistrationDto, ApplicationUser>();
         CreateMap<Course, CourseDto>();
-        CreateMap<CourseModule, CourseModuleDto>();
+        CreateMap<CourseModule, CourseModuleDto>().ForMember(dest => dest.CourseName, opt => opt.MapFrom(src => src.Course.Name)); ;
         CreateMap<ApplicationUser, UserDto>()
             .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => src.UserRoles.Select(ur => ur.Role.Name))); ;
         CreateMap<Activity, ActivityDto>();

--- a/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
@@ -11,6 +11,7 @@ public class ModuleRepository(ApplicationDbContext context)
     public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId) =>
         FindAll()
             .Where(m => m.Course.Users.Any(u => u.Id == userId))
+            .Include(m => m.Course)
             .FirstOrDefaultAsync(m => m.Id == moduleId);
 
     public async Task<CourseModule?> GetUserModuleWithActivitiesAsync(string userId, Guid moduleId)

--- a/Backend/LMS.Shared/DTOs/CourseModuleDtos/CourseModuleDto.cs
+++ b/Backend/LMS.Shared/DTOs/CourseModuleDtos/CourseModuleDto.cs
@@ -9,5 +9,6 @@ public class CourseModuleDto
     public string Description { get; set; } = string.Empty;
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
-    public List<ActivityDto> Activities { get; set; } = [];
+    public string CourseName { get; set; } = string.Empty;
+
 }

--- a/Frontend/src/components/EntityCard.tsx
+++ b/Frontend/src/components/EntityCard.tsx
@@ -1,7 +1,8 @@
-import { Card, Link, Stack, styled, Typography } from '@mui/material';
+import { Card, Stack, styled, Typography } from '@mui/material';
 import { ReactElement } from 'react';
 import Date from './Date';
 import Time from './Time';
+import { NavLink } from 'react-router';
 
 interface IEntityCardProps {
   title: string;
@@ -18,7 +19,8 @@ const StyledCard = styled(Card)(({ theme }) => ({
   padding: theme.spacing(2.5),
 }));
 
-const StyledLink = styled(Link)(({ theme }) => ({
+const StyledLink = styled(NavLink)(({ theme }) => ({
+  textDecoration: 'none',
   transition: 'box-shadow .2s ease, transform .2s ease',
   '&:hover': {
     boxShadow: theme.shadows[2],
@@ -42,13 +44,7 @@ const EntityCard = ({ title, text, link, date, time }: IEntityCardProps): ReactE
     </StyledCard>
   );
 
-  return link ? (
-    <StyledLink href={link} underline="none">
-      {Card}
-    </StyledLink>
-  ) : (
-    Card
-  );
+  return link ? <StyledLink to={link}>{Card}</StyledLink> : Card;
 };
 
 export default EntityCard;

--- a/Frontend/src/components/ModuleActivities.tsx
+++ b/Frontend/src/components/ModuleActivities.tsx
@@ -1,6 +1,6 @@
 import Card from './Card';
 import EntityCard from './EntityCard';
-import { formatDate, formatTime } from '../utilities/helpers';
+import { formatDate, formatTime, sortByDate } from '../utilities/helpers';
 import { Stack } from '@mui/material';
 import theme from '../styles/theme';
 import { IActivity } from '../utilities/types';
@@ -10,9 +10,7 @@ interface ModuleActivitiesProps {
 }
 
 const ModuleActivities = ({ items }: ModuleActivitiesProps) => {
-  const sortedItems = items.sort((a, b) => {
-    return new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
-  });
+  const sortedItems = sortByDate(items, 'startDate');
 
   return (
     <Card title="Aktivititer " titleVariant="h2">

--- a/Frontend/src/components/ModuleActivities.tsx
+++ b/Frontend/src/components/ModuleActivities.tsx
@@ -1,6 +1,6 @@
 import Card from './Card';
 import EntityCard from './EntityCard';
-import { formatDate, formatTime, sortByDate } from '../utilities/helpers';
+import { formatDate, formatTime } from '../utilities/helpers';
 import { Stack } from '@mui/material';
 import theme from '../styles/theme';
 import { IActivity } from '../utilities/types';
@@ -10,12 +10,10 @@ interface ModuleActivitiesProps {
 }
 
 const ModuleActivities = ({ items }: ModuleActivitiesProps) => {
-  const sortedItems = sortByDate(items, 'startDate');
-
   return (
     <Card title="Aktiviteter " titleVariant="h2">
       <Stack spacing={theme.spacing(2)}>
-        {sortedItems.map((item) => (
+        {items.map((item) => (
           <EntityCard
             key={item.name}
             title={`${item.activityType.name}: ${item.name}`}

--- a/Frontend/src/components/ModuleActivities.tsx
+++ b/Frontend/src/components/ModuleActivities.tsx
@@ -13,7 +13,7 @@ const ModuleActivities = ({ items }: ModuleActivitiesProps) => {
   const sortedItems = sortByDate(items, 'startDate');
 
   return (
-    <Card title="Aktivititer " titleVariant="h2">
+    <Card title="Aktiviteter " titleVariant="h2">
       <Stack spacing={theme.spacing(2)}>
         {sortedItems.map((item) => (
           <EntityCard

--- a/Frontend/src/components/ModuleActivities.tsx
+++ b/Frontend/src/components/ModuleActivities.tsx
@@ -10,10 +10,14 @@ interface ModuleActivitiesProps {
 }
 
 const ModuleActivities = ({ items }: ModuleActivitiesProps) => {
+  const sortedItems = items.sort((a, b) => {
+    return new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
+  });
+
   return (
     <Card title="Aktivititer " titleVariant="h2">
       <Stack spacing={theme.spacing(2)}>
-        {items.map((item) => (
+        {sortedItems.map((item) => (
           <EntityCard
             key={item.name}
             title={`${item.activityType.name}: ${item.name}`}

--- a/Frontend/src/components/ModuleActivities.tsx
+++ b/Frontend/src/components/ModuleActivities.tsx
@@ -1,25 +1,27 @@
 import Card from './Card';
-import { mockCourse } from '../utilities/data/mockData';
 import EntityCard from './EntityCard';
-import { formatDate } from '../utilities/helpers';
+import { formatDate, formatTime } from '../utilities/helpers';
 import { Stack } from '@mui/material';
 import theme from '../styles/theme';
+import { IActivity } from '../utilities/types';
 
-const ModuleActivities = () => {
-  const items = mockCourse.activities;
+interface ModuleActivitiesProps {
+  items: IActivity[];
+}
 
+const ModuleActivities = ({ items }: ModuleActivitiesProps) => {
   return (
     <Card title="Aktivititer " titleVariant="h2">
       <Stack spacing={theme.spacing(2)}>
         {items.map((item) => (
           <EntityCard
             key={item.name}
-            title={`${item.type}: ${item.name}`}
+            title={`${item.activityType.name}: ${item.name}`}
             text={item.description}
-            date={{ start: formatDate(item.date) }}
+            date={{ start: formatDate(item.startDate) }}
             time={{
-              start: item.timeStart,
-              end: item.timeEnd,
+              start: formatTime(item.startDate),
+              end: formatTime(item.endDate),
             }}
           />
         ))}

--- a/Frontend/src/pages/CoursePage.tsx
+++ b/Frontend/src/pages/CoursePage.tsx
@@ -44,7 +44,7 @@ const CoursePage = (): ReactElement => {
                         start: formatDate(module.startDate),
                         end: formatDate(module.endDate),
                       }}
-                      link={`modules/${module.id}`}
+                      link={`/module/${module.id}`}
                     />
                   ));
                 }}

--- a/Frontend/src/pages/CoursePage.tsx
+++ b/Frontend/src/pages/CoursePage.tsx
@@ -44,7 +44,7 @@ const CoursePage = (): ReactElement => {
                         start: formatDate(module.startDate),
                         end: formatDate(module.endDate),
                       }}
-                      link={`/module/${module.id}`}
+                      link={`/courses/${resolvedCourse.id}/modules/${module.id}`}
                     />
                   ));
                 }}

--- a/Frontend/src/pages/DashboardPage.tsx
+++ b/Frontend/src/pages/DashboardPage.tsx
@@ -7,7 +7,7 @@ import { useAuthContext } from '../utilities/hooks/useAuthContext';
 import { Await, useLoaderData } from 'react-router';
 import { Suspense } from 'react';
 import { IActivity, ICourse } from '../utilities/types';
-import { formatDate } from '../utilities/helpers';
+import { formatDate, sortByDate } from '../utilities/helpers';
 import theme from '../styles/theme';
 
 const DashboardGrid = styled(Box)(({ theme }) => ({
@@ -62,15 +62,18 @@ const DashboardPage = () => {
         </Card>
         <Suspense>
           <Await resolve={activities}>
-            {(activities: IActivity[]) => (
-              <Card title="Kommande aktiviteter">
-                <CollapsibleList
-                  items={activities}
-                  keyField="id"
-                  renderItem={(activity: IActivity) => <ActivityItem activity={activity} />}
-                />
-              </Card>
-            )}
+            {(activities: IActivity[]) => {
+              const sortedActivites = sortByDate(activities, 'endDate');
+              return (
+                <Card title="Kommande aktiviteter">
+                  <CollapsibleList
+                    items={sortedActivites}
+                    keyField="id"
+                    renderItem={(activity: IActivity) => <ActivityItem activity={activity} />}
+                  />
+                </Card>
+              );
+            }}
           </Await>
         </Suspense>
       </DashboardGrid>

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -19,7 +19,7 @@ const ModulePage = (): ReactElement => {
             <Card title={module.name} titleVariant="h1">
               <Typography mb={theme.layout.gap}>{module.description}</Typography>
               <Stack direction="row" spacing={theme.spacing(6)}>
-                <Typography variant="body2">Del av kurs:</Typography>
+                <Typography variant="body2">Del av kurs: {module.courseName}</Typography>
                 <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
               </Stack>
             </Card>

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -2,10 +2,12 @@ import { ReactElement, Suspense } from 'react';
 import { Await } from 'react-router';
 import { Stack, Typography } from '@mui/material';
 import Card from '../components/Card';
+import ModuleActivities from '../components/ModuleActivities';
+import theme from '../styles/theme';
 
 const ModulePage = (): ReactElement => {
   return (
-    <Stack>
+    <Stack spacing={theme.layout.gapLarge}>
       <Suspense>
         {/* <Await> */}
 
@@ -19,6 +21,7 @@ const ModulePage = (): ReactElement => {
 
         {/* </Await> */}
       </Suspense>
+      <ModuleActivities />
     </Stack>
   );
 };

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -5,8 +5,8 @@ import Card from '../components/Card';
 import ModuleActivities from '../components/ModuleActivities';
 import theme from '../styles/theme';
 import { IActivity, IModule } from '../utilities/types';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { formatDate } from '../utilities/helpers';
+import Date from '../components/Date';
 
 const ModulePage = (): ReactElement => {
   const { module, activities } = useLoaderData();
@@ -20,10 +20,7 @@ const ModulePage = (): ReactElement => {
               <Typography mb={theme.layout.gap}>{module.description}</Typography>
               <Stack direction="row" spacing={theme.spacing(6)}>
                 <Typography variant="body2">Del av kurs:</Typography>
-                <Typography variant="body2" display="flex" alignItems="center" gap={theme.spacing(1)}>
-                  <CalendarMonthIcon fontSize="small" />
-                  Period: {formatDate(module.startDate)} - {formatDate(module.endDate)}
-                </Typography>
+                <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
               </Stack>
             </Card>
           )}

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -1,0 +1,26 @@
+import { ReactElement, Suspense } from 'react';
+import { Await } from 'react-router';
+import { Stack, Typography } from '@mui/material';
+import Card from '../components/Card';
+
+const ModulePage = (): ReactElement => {
+  return (
+    <Stack>
+      <Suspense>
+        {/* <Await> */}
+
+        <Card title="Title" titleVariant="h1">
+          <Typography>
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat veritatis voluptates rem consequuntur esse
+            corporis reprehenderit. Illum quos adipisci animi nisi neque quod debitis eius quasi quibusdam at, dolorum
+            nemo.
+          </Typography>
+        </Card>
+
+        {/* </Await> */}
+      </Suspense>
+    </Stack>
+  );
+};
+
+export default ModulePage;

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -4,7 +4,7 @@ import { Stack, Typography } from '@mui/material';
 import Card from '../components/Card';
 import ModuleActivities from '../components/ModuleActivities';
 import theme from '../styles/theme';
-import { IModule } from '../utilities/types';
+import { IActivity, IModule } from '../utilities/types';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { formatDate } from '../utilities/helpers';
 
@@ -29,7 +29,9 @@ const ModulePage = (): ReactElement => {
           )}
         </Await>
       </Suspense>
-      <ModuleActivities />
+      <Suspense>
+        <Await resolve={activities}>{(activities: IActivity[]) => <ModuleActivities items={activities} />}</Await>
+      </Suspense>
     </Stack>
   );
 };

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -5,7 +5,7 @@ import Card from '../components/Card';
 import ModuleActivities from '../components/ModuleActivities';
 import theme from '../styles/theme';
 import { IActivity, IModule } from '../utilities/types';
-import { formatDate } from '../utilities/helpers';
+import { formatDate, sortByDate } from '../utilities/helpers';
 import Date from '../components/Date';
 
 const ModulePage = (): ReactElement => {
@@ -32,7 +32,12 @@ const ModulePage = (): ReactElement => {
         </Await>
       </Suspense>
       <Suspense>
-        <Await resolve={activities}>{(activities: IActivity[]) => <ModuleActivities items={activities} />}</Await>
+        <Await resolve={activities}>
+          {(activities: IActivity[]) => {
+            const sortedActivites = sortByDate(activities, 'startDate');
+            return <ModuleActivities items={sortedActivites} />;
+          }}
+        </Await>
       </Suspense>
     </Stack>
   );

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -18,8 +18,13 @@ const ModulePage = (): ReactElement => {
           {(module: IModule) => (
             <Card title={module.name} titleVariant="h1">
               <Typography mb={theme.layout.gap}>{module.description}</Typography>
-              <Stack direction="row" spacing={theme.spacing(6)}>
-                <Typography variant="body2">Del av kurs: {module.courseName}</Typography>
+              <Stack direction="row" spacing={theme.spacing(6)} alignItems="center">
+                <Typography variant="body2">
+                  Del av kurs:{' '}
+                  <Typography component="span" fontWeight="bold">
+                    {module.courseName}
+                  </Typography>
+                </Typography>
                 <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
               </Stack>
             </Card>

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -1,25 +1,33 @@
 import { ReactElement, Suspense } from 'react';
-import { Await } from 'react-router';
+import { Await, useLoaderData } from 'react-router';
 import { Stack, Typography } from '@mui/material';
 import Card from '../components/Card';
 import ModuleActivities from '../components/ModuleActivities';
 import theme from '../styles/theme';
+import { IModule } from '../utilities/types';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
+import { formatDate } from '../utilities/helpers';
 
 const ModulePage = (): ReactElement => {
+  const { module, activities } = useLoaderData();
+
   return (
     <Stack spacing={theme.layout.gapLarge}>
       <Suspense>
-        {/* <Await> */}
-
-        <Card title="Title" titleVariant="h1">
-          <Typography>
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Fugiat veritatis voluptates rem consequuntur esse
-            corporis reprehenderit. Illum quos adipisci animi nisi neque quod debitis eius quasi quibusdam at, dolorum
-            nemo.
-          </Typography>
-        </Card>
-
-        {/* </Await> */}
+        <Await resolve={module}>
+          {(module: IModule) => (
+            <Card title={module.name} titleVariant="h1">
+              <Typography mb={theme.layout.gap}>{module.description}</Typography>
+              <Stack direction="row" spacing={theme.spacing(6)}>
+                <Typography variant="body2">Del av kurs:</Typography>
+                <Typography variant="body2" display="flex" alignItems="center" gap={theme.spacing(1)}>
+                  <CalendarMonthIcon fontSize="small" />
+                  Period: {formatDate(module.startDate)} - {formatDate(module.endDate)}
+                </Typography>
+              </Stack>
+            </Card>
+          )}
+        </Await>
       </Suspense>
       <ModuleActivities />
     </Stack>

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -51,14 +51,10 @@ export const router = createBrowserRouter([
       },
       {
         path: 'courses/:courseId/modules/:moduleId',
-        // element: < ModulePage />, // TODO: to be implemented later
+        element: <ModulePage />,
         loader: moduleLoader,
       },
       { path: 'notauthorized', element: <NotAuthorized /> },
-      {
-        path: '/module/:id',
-        element: <ModulePage />,
-      },
     ],
   },
   {

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -49,7 +49,7 @@ export const router = createBrowserRouter([
       },
       { path: 'notauthorized', element: <NotAuthorized /> },
       {
-        path: 'courses/modules/:id',
+        path: '/module/:id',
         element: <ModulePage />,
       },
     ],

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -8,6 +8,7 @@ import { dashboardLoader } from '../utilities/loaders/dashboardLoader';
 import CoursePage from '../pages/CoursePage';
 import { courseLoader, defaultCourseLoader } from '../utilities/loaders/courseLoader';
 import CourseListBoard from '../components/CourseListBoard';
+import ModulePage from '../pages/ModulePage';
 
 export const router = createBrowserRouter([
   {
@@ -42,6 +43,10 @@ export const router = createBrowserRouter([
         path: 'course',
         element: <div />,
         loader: defaultCourseLoader,
+      },
+      {
+        path: 'courses/modules/:id',
+        element: <ModulePage />,
       },
     ],
   },

--- a/Frontend/src/utilities/helpers.ts
+++ b/Frontend/src/utilities/helpers.ts
@@ -15,6 +15,20 @@ export function formatTime(date: string): string {
   }).format(dateFromString);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sortByDate<T extends Record<string, any>>(
+  items: T[],
+  key: keyof T,
+  order: 'asc' | 'desc' = 'asc'
+): T[] {
+  return items.sort((a, b) => {
+    const timeA = new Date(a[key]).getTime();
+    const timeB = new Date(b[key]).getTime();
+
+    return order === 'asc' ? timeA - timeB : timeB - timeA;
+  });
+}
+
 export const requireTeacherRole = () => {
   const tokens = getTokens();
   if (!tokens?.accessToken) {

--- a/Frontend/src/utilities/helpers.ts
+++ b/Frontend/src/utilities/helpers.ts
@@ -7,6 +7,14 @@ export const formatDate = (date: string) => {
   return new Intl.DateTimeFormat('sv-SE').format(dateFromString);
 };
 
+export function formatTime(date: string): string {
+  const dateFromString = new Date(date);
+  return new Intl.DateTimeFormat('sv-SE', {
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(dateFromString);
+}
+
 export const requireTeacherRole = () => {
   const tokens = getTokens();
   if (!tokens?.accessToken) {

--- a/Frontend/src/utilities/types.ts
+++ b/Frontend/src/utilities/types.ts
@@ -52,6 +52,7 @@ export interface IModule {
   startDate: string;
   endDate: string;
   activities: IActivity[];
+  courseName: string;
 }
 export interface ICourseLoader {
   course: Promise<ICourse>;


### PR DESCRIPTION
**Reason for change**

The aim of this PR is to solve these tasks:
- Frontend: Routing for module [#54](https://github.com/lexicon-team-steel/learning-management-system/issues/54)
- Fix: Change Link to NavLink in EntityCard [#130](https://github.com/lexicon-team-steel/learning-management-system/issues/130)

**Changes**

- Added ModulePage and render on Module route.
- Updated ModuleActivities with props and correct structure of data.
- Sorted items on startDate in ModuleActivities.
- Added formatTime function to get time from Date string in HH:mm format.
- Added CourseName to Module in backend.
- Updated EntityCard to use NavLink from React Router.

**How to test**

1. Restart Backend with `make dev`, run frontend with `npm run dev` and log in.
2. Click on a module on CoursePage and you should get redirected to the ModulePage.
3. Let me know if anything doesn't work as expected or if I've missed something!
