### PR TITLE
Fix refresh token bug

### DIFF
--- a/Frontend/src/utilities/loaders/requireAuthLoader.ts
+++ b/Frontend/src/utilities/loaders/requireAuthLoader.ts
@@ -9,11 +9,6 @@ export async function requireAuthLoader({ request }: LoaderFunctionArgs) {
 
   const next = await validateOrRefreshTokens(tokens);
   if (next) {
-    // Update localStorage if refresh gave new tokens
-    const nextRaw = JSON.stringify(next);
-    if (nextRaw !== raw) {
-      localStorage.setItem(TOKENS, nextRaw);
-    }
     return null; // Let the route through
   }
 


### PR DESCRIPTION
**Reason for change**
Fix refresh-tokens bug

As far as I understand, the problem was caused by managing tokens in multiple places. We have a  `fetchWithAuth` function that is typically used in page loaders. This function checks the tokens, refreshes them if needed, and then saves the new tokens to local storage. At the same time, global `requireAuthLoader` does the same check and refresh for every page.
 
This double handling caused a problem when we added `CoursesContext`, which depends on `AuthContext` that keeps tokens in state. The state could become out of sync with local storage because tokens were being refreshed and saved from different places, sometimes in parallel.

**Changes**
-  Unified token refresh by using the same `validateOrRefreshTokens` function in both `fetchWithAuth` and `requireAuthLoader`
- Made `validateOrRefreshTokens` the single source of truth for saving tokens to local storage
- Added a global promise to ensure multiple simultaneous refreshes are coordinated and do not overwrite each other

**How to test**
1. Start projects
2. Wait until the tokens expire and trigger a refresh
3. Verify that no errors occur and tokens are refreshed correctly.
Or comment out
``if (!hasTokenExpired(tokens.accessToken)) return tokens;`` 
in `validateOrRefreshTokens` to force a refresh on every page
