### PR TITLE
Feature/backend create courses functionality

### DIFF
--- a/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,6 +8,6 @@ public interface ICourseRepository : IRepositoryBase<Course>
     public Task<List<Course>> GetUserCoursesAsync(string userId);
     public Task<Course?> GetUserCourseWithModulesAsync(string userId, Guid courseId);
     public Task<List<ApplicationUser>> GetUserCourseParticipantsAsync(string userId, Guid courseId, string? role);
-    void Add(Course course);
+    void CreateCourse(Course course);
 
 }

--- a/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,5 +8,5 @@ public interface ICourseRepository : IRepositoryBase<Course>
     public Task<List<Course>> GetUserCoursesAsync(string userId);
     public Task<Course?> GetUserCourseWithModulesAsync(string userId, Guid courseId);
     public Task<List<ApplicationUser>> GetUserCourseParticipantsAsync(string userId, Guid courseId, string? role);
-
+    public Task<bool> ExistsByNameAsync(string name);
 }

--- a/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,6 +8,5 @@ public interface ICourseRepository : IRepositoryBase<Course>
     public Task<List<Course>> GetUserCoursesAsync(string userId);
     public Task<Course?> GetUserCourseWithModulesAsync(string userId, Guid courseId);
     public Task<List<ApplicationUser>> GetUserCourseParticipantsAsync(string userId, Guid courseId, string? role);
-    void CreateCourse(Course course);
 
 }

--- a/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,5 +8,6 @@ public interface ICourseRepository : IRepositoryBase<Course>
     public Task<List<Course>> GetUserCoursesAsync(string userId);
     public Task<Course?> GetUserCourseWithModulesAsync(string userId, Guid courseId);
     public Task<List<ApplicationUser>> GetUserCourseParticipantsAsync(string userId, Guid courseId, string? role);
+    void Add(Course course);
 
 }

--- a/Backend/Domain.Models/Exceptions/BadRequestException.cs
+++ b/Backend/Domain.Models/Exceptions/BadRequestException.cs
@@ -1,0 +1,5 @@
+namespace Domain.Models.Exceptions;
+
+public class BadRequestException(string message = "Bad Request", int statusCode = 400)
+    : ApiException(message, statusCode)
+{ }

--- a/Backend/Domain.Models/Exceptions/ForbiddenException.cs
+++ b/Backend/Domain.Models/Exceptions/ForbiddenException.cs
@@ -1,0 +1,5 @@
+namespace Domain.Models.Exceptions;
+
+public class ForbiddenException(string message = "Forbidden", int statusCode = 403)
+    : ApiException(message, statusCode)
+{ }

--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -19,5 +19,6 @@ public class MapperProfile : Profile
             .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => src.UserRoles.Select(ur => ur.Role.Name))); ;
         CreateMap<Activity, ActivityDto>();
         CreateMap<ActivityType, ActivityTypeDto>();
+        CreateMap<CreateCourseDto, Course>();
     }
 }

--- a/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -34,4 +34,7 @@ public class CourseRepository(ApplicationDbContext context)
             .ThenInclude(ur => ur.Role)
             .ToListAsync();
     }
+
+    public async Task<bool> ExistsByNameAsync(string name) =>
+        await FindAll().AnyAsync(c => c.Name.ToLower() == name.ToLower());
 }

--- a/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -34,6 +34,4 @@ public class CourseRepository(ApplicationDbContext context)
             .ThenInclude(ur => ur.Role)
             .ToListAsync();
     }
-
-    public void CreateCourse(Course course) => Create(course);
 }

--- a/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -35,5 +35,5 @@ public class CourseRepository(ApplicationDbContext context)
             .ToListAsync();
     }
 
-    public void Add(Course course) => Add(course);
+    public void CreateCourse(Course course) => Create(course);
 }

--- a/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -34,4 +34,6 @@ public class CourseRepository(ApplicationDbContext context)
             .ThenInclude(ur => ur.Role)
             .ToListAsync();
     }
+
+    public void Add(Course course) => Add(course);
 }

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -24,4 +24,19 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
         public async Task<ActionResult<IEnumerable<CourseDto>>> GetAllCourses() =>
             Ok(await courseService.GetAllCoursesAsync());
 
+        [HttpPost]
+        [SwaggerOperation(
+                Summary = "Create a new course",
+                Description = "Creates a new course. Only teachers are allowed.")]
+        [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
+        public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
+        {
+                var course = await courseService.CreateAsync(dto);
+
+                return CreatedAtAction(nameof(CreateCourse), new { status = "ok" });
+        }
+
 }

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -12,31 +12,31 @@ namespace LMS.Presentation.Controllers;
 [Authorize(Roles = "Teacher")]
 public class AdminCoursesController(IServiceManager serviceManager) : ControllerBase
 {
-    private readonly ICourseService courseService = serviceManager.CourseService;
+        private readonly ICourseService courseService = serviceManager.CourseService;
 
-    [HttpGet]
-    [SwaggerOperation(
-            Summary = "Get all courses",
-            Description = "Returns courses for admin.")]
-    [SwaggerResponse(StatusCodes.Status200OK, "List of courses", typeof(IEnumerable<CourseDto>))]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
-    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - You do not have permission to access this resource.")]
-    public async Task<ActionResult<IEnumerable<CourseDto>>> GetAllCourses() =>
-        Ok(await courseService.GetAllCoursesAsync());
+        [HttpGet]
+        [SwaggerOperation(
+                Summary = "Get all courses",
+                Description = "Returns courses for admin.")]
+        [SwaggerResponse(StatusCodes.Status200OK, "List of courses", typeof(IEnumerable<CourseDto>))]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - You do not have permission to access this resource.")]
+        public async Task<ActionResult<IEnumerable<CourseDto>>> GetAllCourses() =>
+            Ok(await courseService.GetAllCoursesAsync());
 
-    [HttpPost]
-    [SwaggerOperation(
-            Summary = "Create a new course",
-            Description = "Creates a new course. Only teachers are allowed.")]
-    [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
-    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
-    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
-    public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
-    {
-        var course = await courseService.CreateAsync(dto);
+        [HttpPost]
+        [SwaggerOperation(
+                Summary = "Create a new course",
+                Description = "Creates a new course. Only teachers are allowed.")]
+        [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
+        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
+        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
+        public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
+        {
+                var course = await courseService.CreateAsync(dto);
 
-        return CreatedAtAction(nameof(CreateCourse), new { status = "ok" });
-    }
+                return CreatedAtAction(nameof(CreateCourse), new { status = "ok" }, course);
+        }
 
 }

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -12,31 +12,31 @@ namespace LMS.Presentation.Controllers;
 [Authorize(Roles = "Teacher")]
 public class AdminCoursesController(IServiceManager serviceManager) : ControllerBase
 {
-        private readonly ICourseService courseService = serviceManager.CourseService;
+    private readonly ICourseService courseService = serviceManager.CourseService;
 
-        [HttpGet]
-        [SwaggerOperation(
-                Summary = "Get all courses",
-                Description = "Returns courses for admin.")]
-        [SwaggerResponse(StatusCodes.Status200OK, "List of courses", typeof(IEnumerable<CourseDto>))]
-        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
-        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - You do not have permission to access this resource.")]
-        public async Task<ActionResult<IEnumerable<CourseDto>>> GetAllCourses() =>
-            Ok(await courseService.GetAllCoursesAsync());
+    [HttpGet]
+    [SwaggerOperation(
+            Summary = "Get all courses",
+            Description = "Returns courses for admin.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "List of courses", typeof(IEnumerable<CourseDto>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - You do not have permission to access this resource.")]
+    public async Task<ActionResult<IEnumerable<CourseDto>>> GetAllCourses() =>
+        Ok(await courseService.GetAllCoursesAsync());
 
-        [HttpPost]
-        [SwaggerOperation(
-                Summary = "Create a new course",
-                Description = "Creates a new course. Only teachers are allowed.")]
-        [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
-        [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
-        [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
-        [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
-        public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
-        {
-                var course = await courseService.CreateAsync(dto);
+    [HttpPost]
+    [SwaggerOperation(
+            Summary = "Create a new course",
+            Description = "Creates a new course. Only teachers are allowed.")]
+    [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
+    public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
+    {
+        var course = await courseService.CreateAsync(dto);
 
-                return CreatedAtAction(nameof(CreateCourse), new { status = "ok" });
-        }
+        return CreatedAtAction(nameof(CreateCourse), new { status = "ok" });
+    }
 
 }

--- a/Backend/LMS.Presentation/Controllers/CoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/CoursesController.cs
@@ -50,4 +50,24 @@ public class CoursesController(IServiceManager serviceManager) : ControllerBase
     {
         return Ok(await courseService.GetCourseParticipantsAsync(courseId, role));
     }
+
+    [HttpPost]
+    [Authorize]
+    [SwaggerOperation(
+        Summary = "Create a new course",
+        Description = "Creates a new course. Only teachers are allowed.")]
+    [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
+    public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
+    {
+        var course = await courseService.CreateAsync(dto);
+
+        return CreatedAtAction(
+            nameof(GetCourseWithModules),
+            new { courseId = course.Id },
+            course
+        );
+    }
 }

--- a/Backend/LMS.Presentation/Controllers/CoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/CoursesController.cs
@@ -50,24 +50,4 @@ public class CoursesController(IServiceManager serviceManager) : ControllerBase
     {
         return Ok(await courseService.GetCourseParticipantsAsync(courseId, role));
     }
-
-    [HttpPost]
-    [Authorize]
-    [SwaggerOperation(
-        Summary = "Create a new course",
-        Description = "Creates a new course. Only teachers are allowed.")]
-    [SwaggerResponse(StatusCodes.Status201Created, "Course created", typeof(CourseDto))]
-    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
-    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
-    public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
-    {
-        var course = await courseService.CreateAsync(dto);
-
-        return CreatedAtAction(
-            nameof(GetCourseWithModules),
-            new { courseId = course.Id },
-            course
-        );
-    }
 }

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -42,6 +42,28 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
         return mapper.Map<IEnumerable<UserDto>>(participants);
     }
 
+    public async Task<CourseDto> CreateAsync(CreateCourseDto dto)
+    {
+        var userId = currentUser.UserId ?? throw new UnauthorizedException();
+
+        if (currentUser.Role != "Teacher")
+        {
+            throw new UnauthorizedException("Only teachers can create courses");
+        }
+
+        if (dto.EndDate < dto.StartDate)
+        {
+            throw new BadRequestException("End date cannot be earlier than start date");
+        }
+
+        var course = mapper.Map<Course>(dto);
+
+        uow.Courses.Add(course);
+        await uow.CompleteAsync();
+
+        return mapper.Map<CourseDto>(course);
+    }
+
     private string GetUserId() =>
         currentUser.UserId ?? throw new UnauthorizedException();
 }

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -46,11 +46,6 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
     {
         var userId = currentUser.UserId ?? throw new UnauthorizedException();
 
-        if (currentUser.Role != "Teacher")
-        {
-            throw new UnauthorizedException("Only teachers can create courses");
-        }
-
         if (dto.EndDate < dto.StartDate)
         {
             throw new BadRequestException("End date cannot be earlier than start date");
@@ -58,7 +53,7 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
 
         var course = mapper.Map<Course>(dto);
 
-        uow.Courses.CreateCourse(course);
+        uow.Courses.Create(course);
         await uow.CompleteAsync();
 
         return mapper.Map<CourseDto>(course);

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -58,7 +58,7 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
 
         var course = mapper.Map<Course>(dto);
 
-        uow.Courses.Add(course);
+        uow.Courses.CreateCourse(course);
         await uow.CompleteAsync();
 
         return mapper.Map<CourseDto>(course);

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -46,6 +46,10 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
     {
         var userId = currentUser.UserId ?? throw new UnauthorizedException();
 
+        var exists = await uow.Courses.ExistsByNameAsync(dto.Name);
+        if (exists)
+            throw new ConflictException($"A course with the name '{dto.Name}' already exists.");
+
         if (dto.EndDate < dto.StartDate)
         {
             throw new BadRequestException("End date cannot be earlier than start date");

--- a/Backend/LMS.Shared/DTOs/CourseDtos/CreateCourseDto.cs
+++ b/Backend/LMS.Shared/DTOs/CourseDtos/CreateCourseDto.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+using LMS.Shared.DTOs.CourseModuleDtos;
+
+namespace LMS.Shared.DTOs.CourseDtos;
+
+public class CreateCourseDto
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+    public string Name { get; set; } = string.Empty;
+    [Required(ErrorMessage = "Description is required")]
+    [StringLength(1000, ErrorMessage = "Description cannot be longer than 1000 characters")]
+    public string Description { get; set; } = string.Empty;
+    [Required(ErrorMessage = "StartDate is required")]
+    public DateTime StartDate { get; set; }
+    [Required(ErrorMessage = "EndDate is required")]
+    public DateTime EndDate { get; set; }
+}

--- a/Backend/Service.Contracts/ICourseService.cs
+++ b/Backend/Service.Contracts/ICourseService.cs
@@ -9,4 +9,5 @@ public interface ICourseService
     public Task<IEnumerable<CourseDto>> GetUserCoursesAsync();
     public Task<CourseDto> GetCourseWithModulesAsync(Guid courseId);
     public Task<IEnumerable<UserDto>> GetCourseParticipantsAsync(Guid courseId, string? role);
+    public Task<CourseDto> CreateAsync(CreateCourseDto dto);
 }


### PR DESCRIPTION
**Reason for change**

As a teacher, I want to be able to create courses so that I can manage course content directly in the system.

**Changes**

- Added CreateCourseDto with validation attributes
- Updated MapperProfile to map CreateCourseDto → Course
- Extended ICourseRepository and CourseRepository with CreateCourse method
- Extended ICourseService and CourseService with CreateAsync(CreateCourseDto dto) that ensures only logged-in users with Teacher role can create courses and validates date ranges (StartDate < EndDate)
- Updated CoursesController with Added POST /api/courses endpoint
- Added Swagger documentation for the new endpoint.

**How to test**

1. Drop & update database if needed.
2. Start backend and open Swagger
3. Call POST /api/courses without login → should return 401 Unauthorized
4. Login as a Student and retry → should return 403 Forbidden
5. Login as a Teacher:
Call POST /api/courses with body -> Should return 201 Created with created course in response.
6. Try invalid payloads:
Missing name -> Should return 400 Bad Request with validation error.
endDate earlier than startDate → should return 400 Bad Request.
7. Verify that the created course appears in the DB.

