### PR TITLE
Feature/backend create activities functionality

### DIFF
--- a/Backend/Domain.Contracts/Repositories/IActivityRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/IActivityRepository.cs
@@ -6,4 +6,5 @@ public interface IActivityRepository : IRepositoryBase<Activity>
 {
     public Task<IEnumerable<Activity>> GetActivitiesByModuleIdAsync(Guid moduleId, CancellationToken cancellationToken);
     public Task<IEnumerable<Activity>> GetUserActivitiesAsync(string userId, CancellationToken cancellationToken);
+    public Task<Activity?> GetActivityWithTypeAsync(Guid activityId);
 }

--- a/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
@@ -4,6 +4,7 @@ namespace Domain.Contracts.Repositories;
 
 public interface IModuleRepository : IRepositoryBase<CourseModule>
 {
+    public Task<CourseModule?> GetModuleWithActivitiesAsync(Guid moduleId);
     public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId);
     public Task<CourseModule?> GetUserModuleWithActivitiesAsync(string userId, Guid moduleId);
 }

--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -21,6 +21,7 @@ public class MapperProfile : Profile
         CreateMap<Activity, ActivityDto>();
         CreateMap<ActivityType, ActivityTypeDto>();
         CreateMap<CreateCourseDto, Course>();
+        CreateMap<ActivityTypeDto, ActivityType>();
         CreateMap<CreateActivityDto, Activity>();
     }
 }

--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -21,5 +21,6 @@ public class MapperProfile : Profile
         CreateMap<Activity, ActivityDto>();
         CreateMap<ActivityType, ActivityTypeDto>();
         CreateMap<CreateCourseDto, Course>();
+        CreateMap<CreateActivityDto, Activity>();
     }
 }

--- a/Backend/LMS.Infrastructure/Repositories/ActivityRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ActivityRepository.cs
@@ -27,4 +27,11 @@ public class ActivityRepository(ApplicationDbContext context)
             .OrderBy(a => a.StartDate)
             .ToListAsync(cancellationToken);
     }
+
+    public async Task<Activity?> GetActivityWithTypeAsync(Guid activityId)
+    {
+        return await FindByCondition(a => a.Id == activityId)
+            .Include(a => a.ActivityType)
+            .FirstOrDefaultAsync();
+    }
 }

--- a/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
@@ -8,6 +8,13 @@ namespace LMS.Infrastructure.Repositories;
 public class ModuleRepository(ApplicationDbContext context)
     : RepositoryBase<CourseModule>(context), IModuleRepository
 {
+    public async Task<CourseModule?> GetModuleWithActivitiesAsync(Guid moduleId)
+    {
+        return await FindAll()
+            .Include(m => m.Activities)
+            .FirstOrDefaultAsync(m => m.Id == moduleId);
+    }
+
     public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId) =>
         FindAll()
             .Where(m => m.Course.Users.Any(u => u.Id == userId))

--- a/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
@@ -1,0 +1,36 @@
+using LMS.Shared.DTOs.ActivityDtos;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Service.Contracts;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace LMS.Presentation.Controllers;
+
+[Route("api/admin/modules")]
+[ApiController]
+[Authorize(Roles = "Teacher")]
+public class AdminModulesController(IServiceManager serviceManager) : ControllerBase
+{
+    private readonly IActivityService activityService = serviceManager.ActivityService;
+
+    [HttpPost("{moduleId}/activities")]
+    [SwaggerOperation(
+        Summary = "Create a new activity in a module",
+        Description = "Creates a new activity for the given module. Only teachers are allowed.")]
+    [SwaggerResponse(StatusCodes.Status201Created, "Activity created", typeof(ActivityDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. dates overlap, endDate < startDate)")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create activities")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Module not found or no access")]
+    public async Task<ActionResult<ActivityDto>> CreateActivity(Guid moduleId, [FromBody] CreateActivityDto dto)
+    {
+        var activity = await activityService.CreateActivityAsync(moduleId, dto);
+
+        return CreatedAtAction(
+            nameof(CreateActivity),
+            new { moduleId = moduleId, activityId = activity.Id },
+            activity
+        );
+    }
+}

--- a/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
@@ -23,6 +23,7 @@ public class AdminModulesController(IServiceManager serviceManager) : Controller
     [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create activities")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Module not found or no access")]
+    [SwaggerResponse(StatusCodes.Status409Conflict, "There was a conflict creating the activity (e.g. overlapping dates)")]
     public async Task<ActionResult<ActivityDto>> CreateActivity(Guid moduleId, [FromBody] CreateActivityDto dto)
     {
         var activity = await activityService.CreateActivityAsync(moduleId, dto);

--- a/Backend/LMS.Services/ActivityService.cs
+++ b/Backend/LMS.Services/ActivityService.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using Domain.Contracts.Repositories;
+using Domain.Models.Entities;
 using Domain.Models.Exceptions;
 using LMS.Shared.DTOs.ActivityDtos;
 using Service.Contracts;
@@ -25,6 +26,31 @@ public class ActivityService(IMapper mapper, IUnitOfWork uow, ICurrentUserServic
         var activities = await uow.Activities.GetUserActivitiesAsync(userId, CancellationToken.None);
 
         return mapper.Map<IEnumerable<ActivityDto>>(activities);
+    }
+
+    public async Task<ActivityDto> CreateActivityAsync(Guid moduleId, CreateActivityDto dto)
+    {
+        if (dto.EndDate <= dto.StartDate)
+            throw new BadRequestException("End date must be after start date");
+
+        var userId = GetUserId();
+
+        var module = await uow.Modules.GetUserModuleWithActivitiesAsync(userId, moduleId);
+        if (module == null)
+            throw new NotFoundException("Module not found or you don't have access");
+
+        var overlapping = module.Activities.Any(a =>
+            dto.StartDate < a.EndDate && dto.EndDate > a.StartDate);
+        if (overlapping)
+            throw new ConflictException("Activity dates overlap with an existing activity in this module");
+
+        var activity = mapper.Map<Activity>(dto);
+        activity.CourseModuleId = moduleId;
+
+        uow.Activities.Create(activity);
+        await uow.CompleteAsync();
+
+        return mapper.Map<ActivityDto>(activity);
     }
 
     private string GetUserId() =>

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -44,7 +44,7 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
 
     public async Task<CourseDto> CreateAsync(CreateCourseDto dto)
     {
-        var userId = currentUser.UserId ?? throw new UnauthorizedException();
+        var userId = GetUserId();
 
         var exists = await uow.Courses.ExistsByNameAsync(dto.Name);
         if (exists)

--- a/Backend/LMS.Shared/DTOs/ActivityDtos/CreateActivityDto.cs
+++ b/Backend/LMS.Shared/DTOs/ActivityDtos/CreateActivityDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LMS.Shared.DTOs.ActivityDtos;
+
+public class CreateActivityDto
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Description is required")]
+    [StringLength(500, ErrorMessage = "Description cannot be longer than 500 characters")]
+    public string Description { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Start date is required")]
+    public DateTime StartDate { get; set; }
+
+    [Required(ErrorMessage = "End date is required")]
+    public DateTime EndDate { get; set; }
+
+    [Required(ErrorMessage = "Activity type is required")]
+    public required ActivityTypeDto ActivityType { get; set; }
+}

--- a/Backend/LMS.Shared/DTOs/ActivityDtos/CreateActivityDto.cs
+++ b/Backend/LMS.Shared/DTOs/ActivityDtos/CreateActivityDto.cs
@@ -19,5 +19,5 @@ public class CreateActivityDto
     public DateTime EndDate { get; set; }
 
     [Required(ErrorMessage = "Activity type is required")]
-    public required ActivityTypeDto ActivityType { get; set; }
+    public Guid ActivityTypeId { get; set; }
 }

--- a/Backend/Service.Contracts/IActivityService.cs
+++ b/Backend/Service.Contracts/IActivityService.cs
@@ -6,5 +6,6 @@ namespace Service.Contracts
     {
         Task<IEnumerable<ActivityDto>> GetActivitiesByModuleIdAsync(Guid moduleId);
         Task<IEnumerable<ActivityDto>> GetUserActivitiesAsync();
+        Task<ActivityDto> CreateActivityAsync(Guid moduleId, CreateActivityDto dto);
     }
 }


### PR DESCRIPTION
**Reason for change**

As a teacher, I want to be able to create activities so that the schedule for modules can stay accurate and up to date.

**Changes**

- Added CreateActivityDto with validation attributes (Name, Description, StartDate, EndDate, ActivityTypeId).
- Updated MapperProfile to map CreateActivityDto → Activity.
- Extended IActivityRepository and ActivityRepository with Create(Activity activity) and GetActivityWithTypeAsync(Guid activityId) for retrieving activities including their ActivityType.
- Extended IActivityService and ActivityService with CreateActivityAsync(Guid moduleId, Guid courseId, CreateActivityDto dto) that:
Validates StartDate < EndDate.
Validates that activities within the same module don’t overlap.
Ensures only teachers can create activities.
- Added POST /api/admin/modules/{moduleId}/activities endpoint in AdminModulesController
- Added Swagger documentation for the new endpoint.

**How to test**

1. Drop & update database if needed.
2. Start backend and open Swagger
3. Call POST /api/admin/modules/{moduleId}/activities without login → should return 401 Unauthorized.
4. Login as a Student and retry → should return 403 Forbidden
5. Login as a Teacher:
Call POST with valid payload → should return 201 Created with created activity including its ActivityType.
6. Try invalid payloads:
Missing name -> Should return 400 Bad Request with validation error.
endDate earlier than startDate → should return 400 Bad Request.
Overlapping activity in the same module → 409 Conflict.
7. Verify that the created activity appears in the DB and is linked to the correct module and ActivityType.

