### PR TITLE
Feature/admin activities page

### DIFF
--- a/Frontend/src/components/ActivityTable.tsx
+++ b/Frontend/src/components/ActivityTable.tsx
@@ -1,0 +1,23 @@
+import { ReactElement } from 'react';
+import Table from './Table';
+import { IActivity } from '../utilities/types';
+import ActivityTableRow from './ActivityTableRow';
+
+interface IActivityTableProps {
+  activities: IActivity[];
+  onEdit: (user: IActivity) => void;
+  onDelete: (user: IActivity) => void;
+}
+
+const ActivityTable = ({ activities, onEdit, onDelete }: IActivityTableProps): ReactElement => (
+  <Table
+    headers={['Aktivitet', 'Aktivitetstyp', 'Datum & Tid', 'Åtgärder']}
+    keyField="id"
+    rows={activities}
+    renderItem={(activity: IActivity) => (
+      <ActivityTableRow activity={activity} onEdit={() => onEdit(activity)} onDelete={() => onDelete(activity)} />
+    )}
+  ></Table>
+);
+
+export default ActivityTable;

--- a/Frontend/src/components/ActivityTableRow.tsx
+++ b/Frontend/src/components/ActivityTableRow.tsx
@@ -20,7 +20,7 @@ const ActivityTableRow = ({ activity, onEdit, onDelete }: IActivityItem): ReactE
         <Typography
           variant="body2"
           color={theme.palette.text.secondary}
-        >{`${formatTime(activity.startDate)} -${formatTime(activity.endDate)}`}</Typography>
+        >{`${formatTime(activity.startDate)} — ${formatTime(activity.endDate)}`}</Typography>
       </TableCell>
       <TableCell align="right" sx={{ paddingX: theme.spacing(1) }}>
         <ActionButtons onEdit={onEdit} onDelete={onDelete} />

--- a/Frontend/src/components/ActivityTableRow.tsx
+++ b/Frontend/src/components/ActivityTableRow.tsx
@@ -1,0 +1,32 @@
+import { TableCell, TableRow, Typography } from '@mui/material';
+import { ReactElement } from 'react';
+import { IActivity } from '../utilities/types';
+import theme from '../styles/theme';
+import ActionButtons from './ActionButtons';
+import { formatDate, formatTime } from '../utilities/helpers';
+
+interface IActivityItem {
+  activity: IActivity;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+const ActivityTableRow = ({ activity, onEdit, onDelete }: IActivityItem): ReactElement => {
+  return (
+    <TableRow>
+      <TableCell>{activity.name}</TableCell>
+      <TableCell>{activity.activityType.name}</TableCell>
+      <TableCell>
+        <Typography>{formatDate(activity.startDate)}</Typography>
+        <Typography
+          variant="body2"
+          color={theme.palette.text.secondary}
+        >{`${formatTime(activity.startDate)} -${formatTime(activity.endDate)}`}</Typography>
+      </TableCell>
+      <TableCell align="right" sx={{ paddingX: theme.spacing(1) }}>
+        <ActionButtons onEdit={onEdit} onDelete={onDelete} />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default ActivityTableRow;

--- a/Frontend/src/components/ModuleTableRow.tsx
+++ b/Frontend/src/components/ModuleTableRow.tsx
@@ -5,14 +5,17 @@ import theme from '../styles/theme';
 import Date from './Date';
 import { formatDate } from '../utilities/helpers';
 import ActionButtons from './ActionButtons';
-import { NavLink } from 'react-router';
+import { NavLink, useParams } from 'react-router';
 
 interface IModuleTableRowProps {
   module: IModule;
   onEdit: () => void;
   onDelete: () => void;
 }
+
 const ModuleTableRow = ({ module, onEdit, onDelete }: IModuleTableRowProps): ReactElement => {
+  const { courseId } = useParams();
+
   return (
     <TableRow>
       <TableCell>{module.name}</TableCell>
@@ -20,7 +23,7 @@ const ModuleTableRow = ({ module, onEdit, onDelete }: IModuleTableRowProps): Rea
         <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
       </TableCell>
       <TableCell>
-        <Link component={NavLink} to={`/admin/modules/${module.id}`} underline="hover">
+        <Link component={NavLink} to={`/admin/courses/${courseId}/modules/${module.id}`} underline="hover">
           Hantera
         </Link>
       </TableCell>

--- a/Frontend/src/pages/AdminActivitiesPage.tsx
+++ b/Frontend/src/pages/AdminActivitiesPage.tsx
@@ -1,0 +1,36 @@
+import { ReactElement, useCallback } from 'react';
+import { IActivity, IAdminActivitiesLoader, IForm, ITable } from '../utilities/types';
+import { Form, useLoaderData } from 'react-router';
+import AdminCrudPage from '../components/AdminCrudPage';
+
+const AdminActivitiesPage = (): ReactElement => {
+  const { module, activityTypes } = useLoaderData<IAdminActivitiesLoader>();
+  const emptyActivity: IActivity = {
+    id: '',
+    name: '',
+    description: '',
+    startDate: '',
+    endDate: '',
+    activityType: activityTypes[0],
+  };
+
+  /**
+   * Futute Form
+   */
+  const FormComponent = useCallback(({ item }: IForm<IActivity>) => <Form>{item.name}</Form>, []);
+
+  const TableComponent = useCallback(() => <div />, []);
+
+  return (
+    <AdminCrudPage
+      items={module.activities}
+      emptyItem={emptyActivity}
+      title={`Module: ${module.name}`}
+      buttonLabel="Skapa ny activity"
+      FormComponent={FormComponent}
+      TableComponent={TableComponent}
+    />
+  );
+};
+
+export default AdminActivitiesPage;

--- a/Frontend/src/pages/AdminActivitiesPage.tsx
+++ b/Frontend/src/pages/AdminActivitiesPage.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useCallback } from 'react';
 import { IActivity, IAdminActivitiesLoader, IForm, ITable } from '../utilities/types';
 import { Form, useLoaderData } from 'react-router';
 import AdminCrudPage from '../components/AdminCrudPage';
+import ActivityTable from '../components/ActivityTable';
 
 const AdminActivitiesPage = (): ReactElement => {
   const { module, activityTypes } = useLoaderData<IAdminActivitiesLoader>();
@@ -19,7 +20,12 @@ const AdminActivitiesPage = (): ReactElement => {
    */
   const FormComponent = useCallback(({ item }: IForm<IActivity>) => <Form>{item.name}</Form>, []);
 
-  const TableComponent = useCallback(() => <div>{module.activities[0].name}</div>, []);
+  const TableComponent = useCallback(
+    ({ items, onEdit, onDelete }: ITable<IActivity>) => (
+      <ActivityTable activities={items} onEdit={onEdit} onDelete={onDelete} />
+    ),
+    []
+  );
 
   return (
     <AdminCrudPage

--- a/Frontend/src/pages/AdminActivitiesPage.tsx
+++ b/Frontend/src/pages/AdminActivitiesPage.tsx
@@ -19,13 +19,13 @@ const AdminActivitiesPage = (): ReactElement => {
    */
   const FormComponent = useCallback(({ item }: IForm<IActivity>) => <Form>{item.name}</Form>, []);
 
-  const TableComponent = useCallback(() => <div />, []);
+  const TableComponent = useCallback(() => <div>{module.activities[0].name}</div>, []);
 
   return (
     <AdminCrudPage
       items={module.activities}
       emptyItem={emptyActivity}
-      title={`Module: ${module.name}`}
+      title={module.name}
       buttonLabel="Skapa ny activity"
       FormComponent={FormComponent}
       TableComponent={TableComponent}

--- a/Frontend/src/pages/AdminActivitiesPage.tsx
+++ b/Frontend/src/pages/AdminActivitiesPage.tsx
@@ -32,6 +32,7 @@ const AdminActivitiesPage = (): ReactElement => {
       items={module.activities}
       emptyItem={emptyActivity}
       title={module.name}
+      subTitle="Hantera aktiviteter"
       buttonLabel="Skapa ny activity"
       FormComponent={FormComponent}
       TableComponent={TableComponent}

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -16,6 +16,8 @@ import { adminUsersLoader } from '../utilities/loaders/adminUsersLoader';
 import AdminUsersPage from '../pages/AdminUsersPage';
 import { adminUsersAction } from '../utilities/actions/adminUsersAction';
 import NotFoundPage from '../pages/NotFoundPage';
+import { adminActivitiesLoader } from '../utilities/loaders/adminActivitiesLoader';
+import AdminActivitiesPage from '../pages/AdminActivitiesPage';
 
 export const router = createBrowserRouter([
   {
@@ -56,6 +58,11 @@ export const router = createBrowserRouter([
         path: 'admin/courses',
         element: <AdminCoursesPage />,
         loader: adminCoursesLoader,
+      },
+      {
+        path: 'admin/modules/:moduleId/activities',
+        element: <AdminActivitiesPage />,
+        loader: adminActivitiesLoader,
       },
       /* ---- Add new routes above this comment for a neater structure ---- */
       { path: 'notauthorized', element: <NotAuthorizedPage /> },

--- a/Frontend/src/router/router.tsx
+++ b/Frontend/src/router/router.tsx
@@ -70,7 +70,7 @@ export const router = createBrowserRouter([
         },
       },
       {
-        path: 'admin/modules/:moduleId',
+        path: 'admin/courses/:courseId/modules/:moduleId',
         element: <AdminActivitiesPage />,
         loader: adminActivitiesLoader,
       },

--- a/Frontend/src/utilities/loaders/adminActivitiesLoader.ts
+++ b/Frontend/src/utilities/loaders/adminActivitiesLoader.ts
@@ -8,6 +8,6 @@ export const adminActivitiesLoader = async ({ params }: LoaderFunctionArgs): Pro
   requireTeacherRole();
   return {
     activityTypes: await fetchWithToken(`${BASE_URL}/admin/activityTypes`),
-    module: await fetchWithToken(`${BASE_URL}/admin/modules/${params.id}`),
+    module: await fetchWithToken(`${BASE_URL}/admin/modules/${params.moduleId}`),
   };
 };

--- a/Frontend/src/utilities/loaders/adminActivitiesLoader.ts
+++ b/Frontend/src/utilities/loaders/adminActivitiesLoader.ts
@@ -1,0 +1,13 @@
+import { fetchWithToken } from '../api/fetchWithToken';
+import { BASE_URL } from '../constants';
+import { IAdminActivitiesLoader } from '../types';
+import { requireTeacherRole } from '../helpers';
+import { LoaderFunctionArgs } from 'react-router';
+
+export const adminActivitiesLoader = async ({ params }: LoaderFunctionArgs): Promise<IAdminActivitiesLoader> => {
+  requireTeacherRole();
+  return {
+    activityTypes: await fetchWithToken(`${BASE_URL}/admin/activityTypes`),
+    module: await fetchWithToken(`${BASE_URL}/admin/modules/${params.id}`),
+  };
+};

--- a/Frontend/src/utilities/types.ts
+++ b/Frontend/src/utilities/types.ts
@@ -125,8 +125,14 @@ export interface ICoursesContext {
 export interface IAdminUsersLoader {
   users: IParticipant[];
 }
+
 export interface IAdminCoursesLoader {
   courses: ICourse[];
+}
+
+export interface IAdminActivitiesLoader {
+  module: IModule;
+  activityTypes: IActivityType[];
 }
 
 export type FormErrorType = Record<string, string>;


### PR DESCRIPTION
**Reason for change**
Admin activities page for module

**Changes**
- Created a new route `/admin/modules/:moduleId`
- Created a loader that fetches data module name, its activities and activityTypes (for future form) from API
- Created `ActivityTableRow` and `ActivityTable` to show activities

**How to test**
1. Start both projects and log in as a teacher
2. Navigate to `/admin/courses`, choose course and click "Hantera" in modules column
3. Choose module and click "Hantera" in activities column
4. Should see module name as a title and a table with module's activities
