### PR TITLE
Features/frontend modules form

### DIFF
--- a/Frontend/src/components/CourseForm.tsx
+++ b/Frontend/src/components/CourseForm.tsx
@@ -1,49 +1,11 @@
 import { ReactElement, useState } from 'react';
 import { FormErrorType, ICourse } from '../utilities/types';
-import { Box, Grid, TextField } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
 import theme from '../styles/theme';
 import AdminPageForm from './AdminPageForm';
-
-interface IStyledTextfield {
-  type?: string;
-  label: string;
-  name: string;
-  value: string;
-  error?: string;
-  required?: boolean;
-}
-
-const StyledTextField = ({ type = 'text', label, name, value, required = true, error }: IStyledTextfield) => (
-  <TextField
-    type={type}
-    label={label}
-    name={name}
-    variant="outlined"
-    defaultValue={value}
-    fullWidth
-    required={required}
-    error={!!error}
-    helperText={error}
-  />
-);
-
-const StyledAreaField = ({ type = 'text', label, name, value, required = true, error }: IStyledTextfield) => (
-  <TextField
-    multiline
-    type={type}
-    label={label}
-    name={name}
-    variant="outlined"
-    defaultValue={value}
-    fullWidth
-    required={required}
-    error={!!error}
-    helperText={error}
-    minRows={3}
-  />
-);
+import TextInput from './TextInput';
 
 interface ICourseFormProps {
   onCancel: () => void;
@@ -67,12 +29,13 @@ const CourseForm = ({ onCancel, course, errors }: ICourseFormProps): ReactElemen
       <input type="hidden" name="endDate" value={endDate?.isValid() ? endDate.format('YYYY-MM-DD') : ''} />
       <Grid container spacing={theme.layout.gap}>
         <Grid size={12}>
-          <StyledTextField label="Titel" name="name" value={course.name} error={errors?.name} />
+          <TextInput label="Titel" name="name" value={course.name} error={errors?.name} />
         </Grid>
         <Grid size={12}>
-          <StyledAreaField
+          <TextInput
             label="Beskrivning"
             name="description"
+            minRows={3}
             value={course.description}
             error={errors?.description}
           />

--- a/Frontend/src/components/ModuleForm.tsx
+++ b/Frontend/src/components/ModuleForm.tsx
@@ -1,42 +1,17 @@
 import { ReactElement, useState } from 'react';
 import { FormErrorType, IModule } from '../utilities/types';
-import { Grid, TextField } from '@mui/material';
+import { Grid } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import theme from '../styles/theme';
 import AdminPageForm from './AdminPageForm';
 import dayjs, { Dayjs } from 'dayjs';
+import TextInput from './TextInput';
 
 interface IModuleFormProps {
   onCancel: () => void;
   module: IModule;
   errors?: FormErrorType;
 }
-
-interface IStyledTextfield {
-  type?: string;
-  label: string;
-  name: string;
-  value: string;
-  error?: string;
-  required?: boolean;
-  rows?: number;
-}
-
-const StyledTextField = ({ type = 'text', label, name, value, required = true, error, rows }: IStyledTextfield) => (
-  <TextField
-    type={type}
-    label={label}
-    name={name}
-    variant="outlined"
-    defaultValue={value}
-    fullWidth
-    required={required}
-    error={!!error}
-    helperText={error}
-    rows={rows}
-    multiline={rows ? true : false}
-  />
-);
 
 const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElement => {
   const action = module.id ? 'edit' : 'create';
@@ -54,14 +29,14 @@ const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElemen
       <input type="hidden" name="endDate" value={endDate?.isValid() ? endDate.format('YYYY-MM-DD') : ''} />
       <Grid container spacing={theme.layout.gap}>
         <Grid size={6}>
-          <StyledTextField label="Titel" name="name" value={module.name} error={errors?.name} />
+          <TextInput label="Titel" name="name" value={module.name} error={errors?.name} />
         </Grid>
         <Grid size={12}>
-          <StyledTextField
+          <TextInput
             type="text"
             label="Beskrivning"
             name="description"
-            rows={3}
+            minRows={3}
             value={module.description}
             error={errors?.description}
           />

--- a/Frontend/src/components/ModuleForm.tsx
+++ b/Frontend/src/components/ModuleForm.tsx
@@ -1,10 +1,10 @@
-import { ReactElement } from 'react';
+import { ReactElement, useState } from 'react';
 import { FormErrorType, IModule } from '../utilities/types';
 import { Grid, TextField } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import theme from '../styles/theme';
-
 import AdminPageForm from './AdminPageForm';
+import dayjs, { Dayjs } from 'dayjs';
 
 interface IModuleFormProps {
   onCancel: () => void;
@@ -43,10 +43,15 @@ const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElemen
   const title = action === 'create' ? 'Ny modul' : 'Redigera modul';
   const submitLabel = action === 'create' ? 'Skapa' : 'Spara';
 
+  const [startDate, setStartDate] = useState<Dayjs | null>(dayjs(module.startDate));
+  const [endDate, setEndDate] = useState<Dayjs | null>(dayjs(module.endDate));
+
   return (
     <AdminPageForm title={title} submitLabel={submitLabel} onCancel={onCancel}>
       <input type="hidden" name="_action" value={action} />
       <input type="hidden" name="id" value={module.id} />
+      <input type="hidden" name="startDate" value={startDate?.isValid() ? startDate.format('YYYY-MM-DD') : ''} />
+      <input type="hidden" name="endDate" value={endDate?.isValid() ? endDate.format('YYYY-MM-DD') : ''} />
       <Grid container spacing={theme.layout.gap}>
         <Grid size={6}>
           <StyledTextField label="Titel" name="name" value={module.name} error={errors?.name} />
@@ -62,10 +67,34 @@ const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElemen
           />
         </Grid>
         <Grid size={3}>
-          <DatePicker label="Startdatum" name="startDate" disablePast />
+          <DatePicker
+            label="Startdatum *"
+            value={startDate}
+            onChange={(date) => setStartDate(date)}
+            format="DD/MM/YYYY"
+            slotProps={{
+              textField: {
+                error: !!errors?.startDate,
+                helperText: errors?.startDate,
+              },
+            }}
+            disablePast
+          />
         </Grid>
         <Grid size={3}>
-          <DatePicker label="Slutdatum" name="endDate" disablePast />
+          <DatePicker
+            label="Slutdatum *"
+            value={endDate}
+            onChange={(date) => setEndDate(date)}
+            format="DD/MM/YYYY"
+            slotProps={{
+              textField: {
+                error: !!errors?.endDate,
+                helperText: errors?.endDate,
+              },
+            }}
+            disablePast
+          />
         </Grid>
       </Grid>
     </AdminPageForm>

--- a/Frontend/src/components/ModuleForm.tsx
+++ b/Frontend/src/components/ModuleForm.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useState } from 'react';
 import { FormErrorType, IModule } from '../utilities/types';
-import { Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers';
 import theme from '../styles/theme';
 import AdminPageForm from './AdminPageForm';
@@ -28,7 +28,7 @@ const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElemen
       <input type="hidden" name="startDate" value={startDate?.isValid() ? startDate.format('YYYY-MM-DD') : ''} />
       <input type="hidden" name="endDate" value={endDate?.isValid() ? endDate.format('YYYY-MM-DD') : ''} />
       <Grid container spacing={theme.layout.gap}>
-        <Grid size={6}>
+        <Grid size={12}>
           <TextInput label="Titel" name="name" value={module.name} error={errors?.name} />
         </Grid>
         <Grid size={12}>
@@ -41,35 +41,35 @@ const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElemen
             error={errors?.description}
           />
         </Grid>
-        <Grid size={3}>
-          <DatePicker
-            label="Startdatum *"
-            value={startDate}
-            onChange={(date) => setStartDate(date)}
-            format="DD/MM/YYYY"
-            slotProps={{
-              textField: {
-                error: !!errors?.startDate,
-                helperText: errors?.startDate,
-              },
-            }}
-            disablePast
-          />
-        </Grid>
-        <Grid size={3}>
-          <DatePicker
-            label="Slutdatum *"
-            value={endDate}
-            onChange={(date) => setEndDate(date)}
-            format="DD/MM/YYYY"
-            slotProps={{
-              textField: {
-                error: !!errors?.endDate,
-                helperText: errors?.endDate,
-              },
-            }}
-            disablePast
-          />
+        <Grid size={12}>
+          <Box display={'flex'} gap={theme.layout.gap}>
+            <DatePicker
+              label="Startdatum *"
+              value={startDate}
+              onChange={(date) => setStartDate(date)}
+              format="DD/MM/YYYY"
+              slotProps={{
+                textField: {
+                  error: !!errors?.startDate,
+                  helperText: errors?.startDate,
+                },
+              }}
+              disablePast
+            />
+            <DatePicker
+              label="Slutdatum *"
+              value={endDate}
+              onChange={(date) => setEndDate(date)}
+              format="DD/MM/YYYY"
+              slotProps={{
+                textField: {
+                  error: !!errors?.endDate,
+                  helperText: errors?.endDate,
+                },
+              }}
+              disablePast
+            />
+          </Box>
         </Grid>
       </Grid>
     </AdminPageForm>

--- a/Frontend/src/components/ModuleForm.tsx
+++ b/Frontend/src/components/ModuleForm.tsx
@@ -1,0 +1,75 @@
+import { ReactElement } from 'react';
+import { FormErrorType, IModule } from '../utilities/types';
+import { Grid, TextField } from '@mui/material';
+import { DatePicker } from '@mui/x-date-pickers';
+import theme from '../styles/theme';
+
+import AdminPageForm from './AdminPageForm';
+
+interface IModuleFormProps {
+  onCancel: () => void;
+  module: IModule;
+  errors?: FormErrorType;
+}
+
+interface IStyledTextfield {
+  type?: string;
+  label: string;
+  name: string;
+  value: string;
+  error?: string;
+  required?: boolean;
+  rows?: number;
+}
+
+const StyledTextField = ({ type = 'text', label, name, value, required = true, error, rows }: IStyledTextfield) => (
+  <TextField
+    type={type}
+    label={label}
+    name={name}
+    variant="outlined"
+    defaultValue={value}
+    fullWidth
+    required={required}
+    error={!!error}
+    helperText={error}
+    rows={rows}
+    multiline={rows ? true : false}
+  />
+);
+
+const ModuleForm = ({ onCancel, module, errors }: IModuleFormProps): ReactElement => {
+  const action = module.id ? 'edit' : 'create';
+  const title = action === 'create' ? 'Ny modul' : 'Redigera modul';
+  const submitLabel = action === 'create' ? 'Skapa' : 'Spara';
+
+  return (
+    <AdminPageForm title={title} submitLabel={submitLabel} onCancel={onCancel}>
+      <input type="hidden" name="_action" value={action} />
+      <input type="hidden" name="id" value={module.id} />
+      <Grid container spacing={theme.layout.gap}>
+        <Grid size={6}>
+          <StyledTextField label="Titel" name="name" value={module.name} error={errors?.name} />
+        </Grid>
+        <Grid size={12}>
+          <StyledTextField
+            type="text"
+            label="Beskrivning"
+            name="description"
+            rows={3}
+            value={module.description}
+            error={errors?.description}
+          />
+        </Grid>
+        <Grid size={3}>
+          <DatePicker label="Startdatum" name="startDate" disablePast />
+        </Grid>
+        <Grid size={3}>
+          <DatePicker label="Slutdatum" name="endDate" disablePast />
+        </Grid>
+      </Grid>
+    </AdminPageForm>
+  );
+};
+
+export default ModuleForm;

--- a/Frontend/src/components/TextInput.tsx
+++ b/Frontend/src/components/TextInput.tsx
@@ -1,0 +1,38 @@
+import { TextField } from '@mui/material';
+import { ReactElement } from 'react';
+
+interface ITextInput {
+  type?: string;
+  label: string;
+  name: string;
+  value: string;
+  error?: string;
+  required?: boolean;
+  minRows?: number;
+}
+
+const TextInput = ({
+  type = 'text',
+  label,
+  name,
+  value,
+  required = true,
+  error,
+  minRows,
+}: ITextInput): ReactElement => (
+  <TextField
+    type={type}
+    label={label}
+    name={name}
+    variant="outlined"
+    defaultValue={value}
+    fullWidth
+    required={required}
+    error={!!error}
+    helperText={error}
+    minRows={minRows}
+    multiline={minRows ? true : false}
+  />
+);
+
+export default TextInput;

--- a/Frontend/src/components/UserForm.tsx
+++ b/Frontend/src/components/UserForm.tsx
@@ -1,33 +1,10 @@
 import { ReactElement } from 'react';
 import { FormErrorType, IParticipant } from '../utilities/types';
-import { FormControlLabel, Grid, Radio, RadioGroup, TextField } from '@mui/material';
+import { FormControlLabel, Grid, Radio, RadioGroup } from '@mui/material';
 import theme from '../styles/theme';
 
 import AdminPageForm from './AdminPageForm';
-
-interface IStyledTextfield {
-  type?: string;
-  label: string;
-  name: string;
-  value: string;
-  error?: string;
-  required?: boolean;
-}
-
-const StyledTextField = ({ type = 'text', label, name, value, required = true, error }: IStyledTextfield) => (
-  <TextField
-    type={type}
-    label={label}
-    name={name}
-    variant="outlined"
-    defaultValue={value}
-    fullWidth
-    required={required}
-    error={!!error}
-    helperText={error}
-  />
-);
-
+import TextInput from './TextInput';
 interface IUserFormProps {
   onCancel: () => void;
   user: IParticipant;
@@ -51,16 +28,16 @@ const UserForm = ({ onCancel, user, errors }: IUserFormProps): ReactElement => {
           </RadioGroup>
         </Grid>
         <Grid size={6}>
-          <StyledTextField label="Förnamn" name="firstName" value={user.firstName} error={errors?.firstName} />
+          <TextInput label="Förnamn" name="firstName" value={user.firstName} error={errors?.firstName} />
         </Grid>
         <Grid size={6}>
-          <StyledTextField label="Efternamn" name="lastName" value={user.lastName} error={errors?.lastName} />
+          <TextInput label="Efternamn" name="lastName" value={user.lastName} error={errors?.lastName} />
         </Grid>
         <Grid size={6}>
-          <StyledTextField type="email" label="E-post" name="email" value={user.email} error={errors?.email} />
+          <TextInput type="email" label="E-post" name="email" value={user.email} error={errors?.email} />
         </Grid>
         <Grid size={6}>
-          <StyledTextField
+          <TextInput
             type="password"
             label="Lösenord"
             name="password"

--- a/Frontend/src/pages/AdminModulesPage.tsx
+++ b/Frontend/src/pages/AdminModulesPage.tsx
@@ -1,16 +1,20 @@
-import { Form, useLoaderData } from 'react-router';
+import { useLoaderData } from 'react-router';
 import ModuleTable from '../components/ModuleTable';
 import { useCallback } from 'react';
 import { IForm, IModule, ITable } from '../utilities/types';
 import AdminCrudPage from '../components/AdminCrudPage';
 import { EMPTY_MODULE } from '../utilities/constants';
+import ModuleForm from '../components/ModuleForm';
 
 const AdminModulesPage = () => {
   const { courseWithModules } = useLoaderData();
   const modules = courseWithModules.modules;
   const courseName = courseWithModules.name;
 
-  const FormComponent = useCallback(({ item }: IForm<IModule>) => <Form>{item.name}</Form>, []);
+  const FormComponent = useCallback(
+    ({ item, onCancel, errors }: IForm<IModule>) => <ModuleForm module={item} onCancel={onCancel} errors={errors} />,
+    []
+  );
 
   const TableComponent = useCallback(
     ({ items, onEdit, onDelete }: ITable<IModule>) => (


### PR DESCRIPTION
**Reason for change**

This PR aims to solve this task [Frontend: Add form for adding modules #154](https://github.com/lexicon-team-steel/learning-management-system/issues/154)

**Changes**

- Created ModuleForm according to design.
- Implemented ModuleForm in AdminModulespage.
- Added TextInput component.
- Replaced TextFields in admin forms with TextInput.

**How to test**

1. If you haven't run `npm install` in a while you might need to.
2. Then start the project as usual.
3. Go to Kurser in admin panel and click on "Hantera" in the column for modules on one of the courses.
4. Click on "Skapa ny modul" and the form should appear.
5. Click on the pen on one of the lines for a module and the form should appear with that modules info filled in.
6. Let me know if I've missed something that should be included in this PR!
