### PR TITLE
Feature/put and delete courses

### DIFF
--- a/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/ICourseRepository.cs
@@ -8,7 +8,6 @@ public interface ICourseRepository : IRepositoryBase<Course>
     public Task<List<Course>> GetUserCoursesAsync(string userId);
     public Task<Course?> GetUserCourseWithModulesAsync(string userId, Guid courseId);
     public Task<List<ApplicationUser>> GetUserCourseParticipantsAsync(string userId, Guid courseId, string? role);
-    public Task<bool> ExistsByNameAsync(string name);
+    public Task<bool> ExistsByNameAsync(string name, Guid? excludeCourseId = null);
     public Task<Course?> GetCourseWithModulesAsync(Guid courseId);
-
 }

--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -24,5 +24,6 @@ public class MapperProfile : Profile
         CreateMap<ActivityTypeDto, ActivityType>();
         CreateMap<CreateActivityDto, Activity>();
         CreateMap<CreateModuleDto, CourseModule>();
+        CreateMap<UpdateCourseDto, Course>();
     }
 }

--- a/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/CourseRepository.cs
@@ -35,8 +35,14 @@ public class CourseRepository(ApplicationDbContext context)
             .ToListAsync();
     }
 
-    public async Task<bool> ExistsByNameAsync(string name) =>
-        await FindAll().AnyAsync(c => c.Name.ToLower() == name.ToLower());
+    public async Task<bool> ExistsByNameAsync(string name, Guid? excludeCourseId = null)
+    {
+        var query = FindAll().Where(c => c.Name.ToLower() == name.ToLower());
+        if (excludeCourseId.HasValue)
+            query = query.Where(c => c.Id != excludeCourseId.Value);
+
+        return await query.AnyAsync();
+    }
 
     public async Task<Course?> GetCourseWithModulesAsync(Guid courseId)
     {

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -45,6 +45,7 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. endDate < startDate)")]
     [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can create courses")]
+    [SwaggerResponse(StatusCodes.Status409Conflict, "A course with the same name already exists")]
     public async Task<ActionResult<CourseDto>> CreateCourse([FromBody] CreateCourseDto dto)
     {
         var course = await courseService.CreateAsync(dto);

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -67,4 +67,34 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
         return CreatedAtAction(nameof(CreateModule), new { status = "ok" }, module);
     }
 
+    [HttpPut("{courseId}")]
+    [SwaggerOperation(
+        Summary = "Update an existing course",
+        Description = "Allows teachers to update course details.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course updated successfully", typeof(CourseDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can edit courses")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Course not found")]
+    public async Task<ActionResult<CourseDto>> UpdateCourse(Guid courseId, [FromBody] UpdateCourseDto dto)
+    {
+        var updatedCourse = await courseService.UpdateAsync(courseId, dto);
+        return Ok(updatedCourse);
+    }
+
+
+    [HttpDelete("{courseId}")]
+    [SwaggerOperation(
+        Summary = "Delete a course",
+        Description = "Deletes a course. Only teachers can perform this action.")]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "Course deleted successfully")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can delete courses")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Course not found")]
+    public async Task<IActionResult> DeleteCourse(Guid courseId)
+    {
+        await courseService.DeleteAsync(courseId);
+        return NoContent();
+    }
+
 }

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -88,14 +88,14 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
     [SwaggerOperation(
         Summary = "Delete a course",
         Description = "Deletes a course. Only teachers can perform this action.")]
-    [SwaggerResponse(StatusCodes.Status204NoContent, "Course deleted successfully")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Course deleted successfully")]
     [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized")]
     [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can delete courses")]
     [SwaggerResponse(StatusCodes.Status404NotFound, "Course not found")]
     public async Task<IActionResult> DeleteCourse(Guid courseId)
     {
         await courseService.DeleteAsync(courseId);
-        return NoContent();
+        return Ok(new { success = true });
     }
 
 }

--- a/Backend/LMS.Services/CourseService.cs
+++ b/Backend/LMS.Services/CourseService.cs
@@ -54,14 +54,7 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
     {
         var userId = GetUserId();
 
-        var exists = await uow.Courses.ExistsByNameAsync(dto.Name);
-        if (exists)
-            throw new ConflictException($"A course with the name '{dto.Name}' already exists.");
-
-        if (dto.EndDate < dto.StartDate)
-        {
-            throw new BadRequestException("End date cannot be earlier than start date");
-        }
+        await ValidateCourseAsync(dto.Name, dto.StartDate, dto.EndDate);
 
         var course = mapper.Map<Course>(dto);
 
@@ -69,6 +62,45 @@ public class CourseService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
         await uow.CompleteAsync();
 
         return mapper.Map<CourseDto>(course);
+    }
+
+    public async Task<CourseDto> UpdateAsync(Guid courseId, UpdateCourseDto dto)
+    {
+        var userId = GetUserId();
+
+        var course = await uow.Courses.GetCourseWithModulesAsync(courseId);
+        if (course == null)
+            throw new NotFoundException("Course not found");
+
+        await ValidateCourseAsync(dto.Name, dto.StartDate, dto.EndDate, courseId);
+
+        mapper.Map(dto, course);
+
+        uow.Courses.Update(course);
+        await uow.CompleteAsync();
+
+        return mapper.Map<CourseDto>(course);
+    }
+
+    public async Task DeleteAsync(Guid courseId)
+    {
+        var course = await uow.Courses.GetCourseWithModulesAsync(courseId);
+        if (course == null)
+            throw new NotFoundException("Course not found");
+
+        uow.Courses.Delete(course);
+        await uow.CompleteAsync();
+    }
+
+
+    private async Task ValidateCourseAsync(string name, DateTime startDate, DateTime endDate, Guid? existingCourseId = null)
+    {
+        if (endDate < startDate)
+            throw new BadRequestException("End date cannot be earlier than start date");
+
+        var exists = await uow.Courses.ExistsByNameAsync(name, existingCourseId);
+        if (exists)
+            throw new ConflictException($"A course with the name '{name}' already exists.");
     }
 
     private string GetUserId() =>

--- a/Backend/LMS.Shared/DTOs/CourseDtos/UpdateCourseDto.cs
+++ b/Backend/LMS.Shared/DTOs/CourseDtos/UpdateCourseDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LMS.Shared.DTOs.CourseDtos;
+
+public class UpdateCourseDto
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Description is required")]
+    [StringLength(1000, ErrorMessage = "Description cannot be longer than 1000 characters")]
+    public string Description { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "StartDate is required")]
+    public DateTime StartDate { get; set; }
+
+    [Required(ErrorMessage = "EndDate is required")]
+    public DateTime EndDate { get; set; }
+}

--- a/Backend/Service.Contracts/ICourseService.cs
+++ b/Backend/Service.Contracts/ICourseService.cs
@@ -11,4 +11,6 @@ public interface ICourseService
     public Task<CourseDto> GetCourseWithModulesAsync(Guid courseId);
     public Task<IEnumerable<UserDto>> GetCourseParticipantsAsync(Guid courseId, string? role);
     public Task<CourseDto> CreateAsync(CreateCourseDto dto);
+    public Task<CourseDto> UpdateAsync(Guid courseId, UpdateCourseDto dto);
+    public Task DeleteAsync(Guid courseId);
 }


### PR DESCRIPTION
**Reason for change**

As a teacher, I want to be able to edit and delete courses so that I can keep course information up to date or remove outdated ones.

**Changes**

-  Added UpdateCourseDto with validation attributes.
- Updated MapperProfile to map UpdateCourseDto → Course.
- Extended ExistsByNameAsync in ICourseRepository and CourseRepository to support checking for unique course names during updates and prevent it from not letting you leave the name unchanged.
- Extended ICourseService and CourseService with UpdateAsync and DeleteAsync and added shared private method ValidateCourseAsync.
- Added PUT /api/courses/{courseId} and DELETE /api/courses/{courseId} endpoints in AdminCoursesController.

**How to test**

1. Start backend and open Swagger.
2. Login as:
Student → All PUT/DELETE requests should return 403 Forbidden.
Teacher → Should be authorized.
3. Update course (PUT /api/courses/{courseId}):
Valid update → returns 200 OK with updated course data.
Invalid payload (missing name or endDate < startDate) → 400 Bad Request.
Nonexistent courseId → 404 Not Found.
Duplicate name (existing course) → 409 Conflict.
4. Delete course (DELETE /api/courses/{courseId}):
Existing course → returns 204 No Content and course removed from DB.
Invalid or missing courseId → 404 Not Found.
5. Verify in database that updates and deletions persist correctly.
