### PR TITLE
Feature/backend put and delete activities

### DIFF
--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -27,5 +27,6 @@ public class MapperProfile : Profile
         CreateMap<UpdateCourseDto, Course>();
         CreateMap<UserUpdateDto, ApplicationUser>()
             .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email)); ;
+        CreateMap<UpdateActivityDto, Activity>();
     }
 }

--- a/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminModulesController.cs
@@ -46,4 +46,35 @@ public class AdminModulesController(IServiceManager serviceManager) : Controller
     [SwaggerResponse(StatusCodes.Status404NotFound, "Module not found")]
     public async Task<ActionResult<CourseModuleDto>> GetCourseWithModules(Guid moduleId) =>
         Ok(await moduleService.GetModuleWithActivitiesAsync(moduleId));
+
+
+    [HttpPut("{moduleId}/activities/{activityId}")]
+    [SwaggerOperation(
+        Summary = "Update an existing activity",
+        Description = "Updates an existing activity within a module. Only teachers are allowed.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Activity updated successfully", typeof(ActivityDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed (e.g. invalid date range)")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can update activities")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Activity or module not found")]
+    [SwaggerResponse(StatusCodes.Status409Conflict, "Overlapping activity dates")]
+    public async Task<ActionResult<ActivityDto>> UpdateActivity(Guid moduleId, Guid activityId, [FromBody] UpdateActivityDto dto)
+    {
+        var updatedActivity = await activityService.UpdateActivityAsync(activityId, dto);
+        return Ok(updatedActivity);
+    }
+
+    [HttpDelete("{moduleId}/activities/{activityId}")]
+    [SwaggerOperation(
+        Summary = "Delete an activity",
+        Description = "Deletes an activity within a module. Only teachers are allowed.")]
+    [SwaggerResponse(StatusCodes.Status204NoContent, "Activity deleted successfully")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized - JWT token missing or invalid")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can delete activities")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Activity not found")]
+    public async Task<IActionResult> DeleteActivity(Guid moduleId, Guid activityId)
+    {
+        await activityService.DeleteActivityAsync(activityId);
+        return Ok(new { success = true });
+    }
 }

--- a/Backend/LMS.Shared/DTOs/ActivityDtos/UpdateActivityDto.cs
+++ b/Backend/LMS.Shared/DTOs/ActivityDtos/UpdateActivityDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LMS.Shared.DTOs.ActivityDtos;
+
+public class UpdateActivityDto
+{
+    [Required(ErrorMessage = "Name is required")]
+    [StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Description is required")]
+    [StringLength(500, ErrorMessage = "Description cannot be longer than 500 characters")]
+    public string Description { get; set; } = string.Empty;
+
+    [Required(ErrorMessage = "Start date is required")]
+    public DateTime StartDate { get; set; }
+
+    [Required(ErrorMessage = "End date is required")]
+    public DateTime EndDate { get; set; }
+
+    [Required(ErrorMessage = "Activity type is required")]
+    public Guid ActivityTypeId { get; set; }
+}

--- a/Backend/Service.Contracts/IActivityService.cs
+++ b/Backend/Service.Contracts/IActivityService.cs
@@ -7,5 +7,7 @@ namespace Service.Contracts
         Task<IEnumerable<ActivityDto>> GetActivitiesByModuleIdAsync(Guid moduleId);
         Task<IEnumerable<ActivityDto>> GetUserActivitiesAsync();
         Task<ActivityDto> CreateActivityAsync(Guid moduleId, CreateActivityDto dto);
+        Task<ActivityDto> UpdateActivityAsync(Guid activityId, UpdateActivityDto dto);
+        Task DeleteActivityAsync(Guid activityId);
     }
 }


### PR DESCRIPTION
**Reason for change**

As a teacher, I want to be able to edit and delete activities

**Changes**

-  Added UpdateActivityDto with validation attributes.
- Updated MapperProfile to map UpdateActivityDto → Activity.
- Extended IActivityService and ActivityService with update and delete and added shared private methods for validation.
- Added PUT and DELETE endpoints in AdminModulesController.

**How to test**

1. Start backend and open Swagger.
2. Login as:
Student → All PUT/DELETE requests should return 403 Forbidden.
Teacher → Should be authorized.
3. Update activity:
Valid update → returns 200 OK
Invalid payload should return 40.. something depending on the error
4. Delete activity:
Existing activity → returns 200 OK and course removed from DB.
Invalid or missing courseId → 404 Not Found.
5. Verify in database that updates and deletions persist correctly.