### PR TITLE
Feature/backend edit modules

### DIFF
--- a/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
@@ -7,5 +7,5 @@ public interface IModuleRepository : IRepositoryBase<CourseModule>
     public Task<CourseModule?> GetModuleWithActivitiesAsync(Guid moduleId);
     public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId);
     public Task<CourseModule?> GetUserModuleWithActivitiesAsync(string userId, Guid moduleId);
-    public Task<bool> ExistsByNameAsync(Guid courseId, string name);
+    public Task<bool> ExistsByNameAsync(Guid courseId, string name, Guid? excludeModuleId = null);
 }

--- a/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
@@ -8,4 +8,6 @@ public interface IModuleRepository : IRepositoryBase<CourseModule>
     public Task<CourseModule?> GetUserModuleAsync(string userId, Guid moduleId);
     public Task<CourseModule?> GetUserModuleWithActivitiesAsync(string userId, Guid moduleId);
     public Task<bool> ExistsByNameAsync(Guid courseId, string name, Guid? excludeModuleId = null);
+    public Task<CourseModule?> GetModuleAsync(Guid moduleId);
+
 }

--- a/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
+++ b/Backend/Domain.Contracts/Repositories/IModuleRepository.cs
@@ -5,7 +5,7 @@ namespace Domain.Contracts.Repositories;
 public interface IModuleRepository : IRepositoryBase<CourseModule>
 {
     public Task<CourseModule?> GetModuleWithActivitiesAsync(Guid moduleId);
-    public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId);
+    public Task<CourseModule?> GetUserModuleAsync(string userId, Guid moduleId);
     public Task<CourseModule?> GetUserModuleWithActivitiesAsync(string userId, Guid moduleId);
     public Task<bool> ExistsByNameAsync(Guid courseId, string name, Guid? excludeModuleId = null);
 }

--- a/Backend/LMS.Infrastructure/Data/MapperProfile.cs
+++ b/Backend/LMS.Infrastructure/Data/MapperProfile.cs
@@ -25,6 +25,7 @@ public class MapperProfile : Profile
         CreateMap<CreateActivityDto, Activity>();
         CreateMap<CreateModuleDto, CourseModule>();
         CreateMap<UpdateCourseDto, Course>();
+        CreateMap<UpdateModuleDto, CourseModule>();
         CreateMap<UserUpdateDto, ApplicationUser>()
             .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Email)); ;
     }

--- a/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
@@ -37,4 +37,9 @@ public class ModuleRepository(ApplicationDbContext context)
 
         return await query.AnyAsync();
     }
+
+    public async Task<CourseModule?> GetModuleAsync(Guid moduleId) =>
+        await FindAll()
+            .Where(m => m.Id == moduleId)
+            .FirstOrDefaultAsync();
 }

--- a/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
@@ -29,6 +29,12 @@ public class ModuleRepository(ApplicationDbContext context)
                 .ThenInclude(a => a.ActivityType)
             .FirstOrDefaultAsync();
     }
-    public async Task<bool> ExistsByNameAsync(Guid courseId, string name) =>
-        await FindAll().Where(m => m.CourseId == courseId).AnyAsync(m => m.Name.ToLower() == name.ToLower());
+    public async Task<bool> ExistsByNameAsync(Guid courseId, string name, Guid? excludeModuleId = null)
+    {
+        var query = FindAll().Where(m => m.CourseId == courseId).Where(m => m.Name.ToLower() == name.ToLower());
+        if (excludeModuleId.HasValue)
+            query = query.Where(m => m.Id != excludeModuleId.Value);
+
+        return await query.AnyAsync();
+    }
 }

--- a/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
+++ b/Backend/LMS.Infrastructure/Repositories/ModuleRepository.cs
@@ -16,7 +16,7 @@ public class ModuleRepository(ApplicationDbContext context)
             .FirstOrDefaultAsync(m => m.Id == moduleId);
     }
 
-    public Task<CourseModule?> GetModuleAsync(string userId, Guid moduleId) =>
+    public Task<CourseModule?> GetUserModuleAsync(string userId, Guid moduleId) =>
         FindAll()
             .Where(m => m.Course.Users.Any(u => u.Id == userId))
             .Include(m => m.Course)

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -113,4 +113,18 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
         return Ok(new { success = true });
     }
 
+    [HttpDelete("{courseId}/modules/{moduleId}")]
+    [SwaggerOperation(
+        Summary = "Delete a module",
+        Description = "Deletes a module. Only teachers can perform this action.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Module deleted successfully")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can delete modules")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Module not found")]
+    public async Task<IActionResult> DeleteModule(Guid courseId, Guid moduleId)
+    {
+        await moduleService.DeleteAsync(courseId, moduleId);
+        return Ok(new { success = true });
+    }
+
 }

--- a/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
+++ b/Backend/LMS.Presentation/Controllers/AdminCoursesController.cs
@@ -83,6 +83,21 @@ public class AdminCoursesController(IServiceManager serviceManager) : Controller
         return Ok(updatedCourse);
     }
 
+    [HttpPut("{courseId}/modules/{moduleId}")]
+    [SwaggerOperation(
+        Summary = "Update an existing module",
+        Description = "Allows teachers to update module details.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Module updated successfully", typeof(CourseModuleDto))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation failed")]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Unauthorized")]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Forbidden - only teachers can edit modules")]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Module not found")]
+    public async Task<ActionResult<CourseModuleDto>> UpdateModule(Guid courseId, Guid moduleId, [FromBody] UpdateModuleDto dto)
+    {
+        var updatedModule = await moduleService.UpdateAsync(courseId, moduleId, dto);
+        return Ok(updatedModule);
+    }
+
 
     [HttpDelete("{courseId}")]
     [SwaggerOperation(

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -12,7 +12,7 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
     public async Task<CourseModuleDto> GetUserModuleAsync(Guid moduleId)
     {
         var userId = currentUser.UserId ?? throw new UnauthorizedException();
-        var module = await uow.Modules.GetModuleAsync(userId, moduleId);
+        var module = await uow.Modules.GetUserModuleAsync(userId, moduleId);
 
         if (module == null) throw new NotFoundException("Module not found or you don't have access");
 

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -42,6 +42,22 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
 
     }
 
+    public async Task<CourseModuleDto> UpdateAsync(Guid courseId, Guid moduleId, UpdateModuleDto dto)
+    {
+        var module = await uow.Modules.GetModuleAsync(moduleId);
+        if (module == null)
+            throw new NotFoundException("Course not found");
+
+        await ValidateModuleAsync(courseId, dto.Name, dto.StartDate, dto.EndDate, moduleId);
+
+        mapper.Map(dto, module);
+
+        uow.Modules.Update(module);
+        await uow.CompleteAsync();
+
+        return mapper.Map<CourseModuleDto>(module);
+    }
+
     private async Task ValidateModuleAsync(Guid courseId, string name, DateTime startDate, DateTime endDate, Guid? existingModuleId = null)
     {
         if (endDate < startDate)

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -89,7 +89,7 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
         if (overlapping)
             throw new ConflictException("Module dates overlap with an existing module in this course");
 
-        if (startDate < course.StartDate || startDate > course.EndDate || endDate < course.StartDate || endDate > course.EndDate)
+        if (startDate < course.StartDate || endDate > course.EndDate)
             throw new BadRequestException("Module dates must be set within course dates.");
     }
 }

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -88,5 +88,8 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
 
         if (overlapping)
             throw new ConflictException("Module dates overlap with an existing module in this course");
+
+        if (startDate < course.StartDate || startDate > course.EndDate || endDate < course.StartDate || endDate > course.EndDate)
+            throw new BadRequestException("Module dates must be set within course dates.");
     }
 }

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -46,7 +46,7 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
     {
         var module = await uow.Modules.GetModuleAsync(moduleId);
         if (module == null)
-            throw new NotFoundException("Course not found");
+            throw new NotFoundException("Module not found");
 
         await ValidateModuleAsync(courseId, dto.Name, dto.StartDate, dto.EndDate, moduleId);
 
@@ -56,6 +56,16 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
         await uow.CompleteAsync();
 
         return mapper.Map<CourseModuleDto>(module);
+    }
+
+    public async Task DeleteAsync(Guid courseId, Guid moduleId)
+    {
+        var module = await uow.Modules.GetModuleAsync(moduleId);
+        if (module == null)
+            throw new NotFoundException("Module not found");
+
+        uow.Modules.Delete(module);
+        await uow.CompleteAsync();
     }
 
     private async Task ValidateModuleAsync(Guid courseId, string name, DateTime startDate, DateTime endDate, Guid? existingModuleId = null)

--- a/Backend/LMS.Services/ModuleService.cs
+++ b/Backend/LMS.Services/ModuleService.cs
@@ -82,6 +82,10 @@ public class ModuleService(IMapper mapper, IUnitOfWork uow, ICurrentUserService 
             throw new NotFoundException("Course not found");
 
         var overlapping = course.Modules.Any(m => startDate < m.EndDate && endDate > m.StartDate);
+
+        if (existingModuleId.HasValue)
+            overlapping = course.Modules.Where(m => m.Id != existingModuleId.Value).Any(m => startDate < m.EndDate && endDate > m.StartDate);
+
         if (overlapping)
             throw new ConflictException("Module dates overlap with an existing module in this course");
     }

--- a/Backend/LMS.Shared/DTOs/CourseModuleDtos/UpdateModuleDto.cs
+++ b/Backend/LMS.Shared/DTOs/CourseModuleDtos/UpdateModuleDto.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+public class UpdateModuleDto
+{
+	[Required(ErrorMessage = "Name is required")]
+	[StringLength(100, ErrorMessage = "Name cannot be longer than 100 characters")]
+	public string Name { get; set; } = string.Empty;
+	[Required(ErrorMessage = "Description is required")]
+	[StringLength(1000, ErrorMessage = "Description cannot be longer than 1000 characters")]
+	public string Description { get; set; } = string.Empty;
+	[Required(ErrorMessage = "StartDate is required")]
+	public DateTime StartDate { get; set; }
+	[Required(ErrorMessage = "EndDate is required")]
+	public DateTime EndDate { get; set; }
+}

--- a/Backend/Service.Contracts/IModuleService.cs
+++ b/Backend/Service.Contracts/IModuleService.cs
@@ -8,5 +8,6 @@ public interface IModuleService
     public Task<CourseModuleDto> GetModuleWithActivitiesAsync(Guid moduleId);
     public Task<CourseModuleDto> CreateModuleAsync(Guid courseId, CreateModuleDto dto);
     public Task<CourseModuleDto> UpdateAsync(Guid courseId, Guid moduleId, UpdateModuleDto dto);
+    public Task DeleteAsync(Guid courseId, Guid moduleId);
 }
 

--- a/Backend/Service.Contracts/IModuleService.cs
+++ b/Backend/Service.Contracts/IModuleService.cs
@@ -7,5 +7,6 @@ public interface IModuleService
     public Task<CourseModuleDto> GetUserModuleAsync(Guid moduleId);
     public Task<CourseModuleDto> GetModuleWithActivitiesAsync(Guid moduleId);
     public Task<CourseModuleDto> CreateModuleAsync(Guid courseId, CreateModuleDto dto);
+    public Task<CourseModuleDto> UpdateAsync(Guid courseId, Guid moduleId, UpdateModuleDto dto);
 }
 


### PR DESCRIPTION
**Reason for change**

This PR aims to solve this task [Backend: Edit modules functionality #173](https://github.com/lexicon-team-steel/learning-management-system/issues/173), by adding functionality on Backend to edit and delete modules.

**Changes**

- Added UpdateModuleDTO.
- Added provate method to validate modules in ModuleService.
- Renamed GetModuleAsync to GetUserModuleAsync and added a new GetModuleAsync to get module not connected to a user and without activities.
- Added UpdateAsync and DeleteAsync to ModuleService.
- Added PUT and DELETE requests to endpoint `/api/admin/courses/{courseId}/modules/{moduleId}`.
- Added checks for both activities and modules to only be able to set dates within their parent module/course.

**How to test**

1. Start backend and open Swagger.
2. Login as:
Student → All PUT/DELETE requests should return 403 Forbidden.
Teacher → Should be authorized.
3. Update module (PUT /api/admin/courses/{courseId}/modules/{moduleId}):
Valid update → returns 200 OK with updated module data.
Invalid payload (missing name or endDate < startDate) → 400 Bad Request.
Nonexistent moduleId → 404 Not Found.
Duplicate name (existing module) → 409 Conflict.
4. Delete module (DELETE /api/admin/courses/{courseId}/modules/{moduleId}):
Existing module → returns 204 No Content and module removed from DB.
Invalid or missing moduleId → 404 Not Found.
5. Try creating and updating both a module and an activity with dates outside of it's parent course/module and make sure it's not possible.
5. Verify in database that updates and deletions persist correctly.
