### PR TITLE
Features/frontend back link

### DIFF
--- a/Frontend/src/components/BackLink.tsx
+++ b/Frontend/src/components/BackLink.tsx
@@ -1,0 +1,28 @@
+import { ReactElement } from 'react';
+import { Link } from '@mui/material';
+import { useNavigate } from 'react-router';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import theme from '../styles/theme';
+
+interface IBackLinkProps {
+  name?: string;
+}
+
+const BackLink = ({ name }: IBackLinkProps): ReactElement => {
+  const navigate = useNavigate();
+
+  return (
+    <Link
+      component="button"
+      onClick={() => navigate(-1)}
+      display="flex"
+      alignItems="center"
+      underline="hover"
+      gap={theme.spacing(1)}
+    >
+      <ArrowBackIcon fontSize="small" /> {name ? `Tillbaka till ${name}` : 'Tillbaka'}
+    </Link>
+  );
+};
+
+export default BackLink;

--- a/Frontend/src/pages/AdminActivitiesPage.tsx
+++ b/Frontend/src/pages/AdminActivitiesPage.tsx
@@ -3,6 +3,9 @@ import { IActivity, IAdminActivitiesLoader, IForm, ITable } from '../utilities/t
 import { Form, useLoaderData } from 'react-router';
 import AdminCrudPage from '../components/AdminCrudPage';
 import ActivityTable from '../components/ActivityTable';
+import { Stack } from '@mui/material';
+import BackLink from '../components/BackLink';
+import theme from '../styles/theme';
 
 const AdminActivitiesPage = (): ReactElement => {
   const { module, activityTypes } = useLoaderData<IAdminActivitiesLoader>();
@@ -28,15 +31,18 @@ const AdminActivitiesPage = (): ReactElement => {
   );
 
   return (
-    <AdminCrudPage
-      items={module.activities}
-      emptyItem={emptyActivity}
-      title={module.name}
-      subTitle="Hantera aktiviteter"
-      buttonLabel="Skapa ny aktivitet"
-      FormComponent={FormComponent}
-      TableComponent={TableComponent}
-    />
+    <Stack spacing={theme.layout.gapLarge}>
+      <BackLink name="Hantera moduler" />
+      <AdminCrudPage
+        items={module.activities}
+        emptyItem={emptyActivity}
+        title={module.name}
+        subTitle="Hantera aktiviteter"
+        buttonLabel="Skapa ny aktivitet"
+        FormComponent={FormComponent}
+        TableComponent={TableComponent}
+      />
+    </Stack>
   );
 };
 

--- a/Frontend/src/pages/AdminModulesPage.tsx
+++ b/Frontend/src/pages/AdminModulesPage.tsx
@@ -5,6 +5,9 @@ import { IForm, IModule, ITable } from '../utilities/types';
 import AdminCrudPage from '../components/AdminCrudPage';
 import { EMPTY_MODULE } from '../utilities/constants';
 import ModuleForm from '../components/ModuleForm';
+import BackLink from '../components/BackLink';
+import { Stack } from '@mui/material';
+import theme from '../styles/theme';
 
 const AdminModulesPage = () => {
   const { courseWithModules } = useLoaderData();
@@ -24,15 +27,18 @@ const AdminModulesPage = () => {
   );
 
   return (
-    <AdminCrudPage<IModule>
-      items={modules}
-      emptyItem={EMPTY_MODULE}
-      title={courseName}
-      subTitle="Hantera moduler"
-      buttonLabel="Skapa ny modul"
-      FormComponent={FormComponent}
-      TableComponent={TableComponent}
-    />
+    <Stack spacing={theme.layout.gapLarge}>
+      <BackLink name="Hantera kurser" />
+      <AdminCrudPage<IModule>
+        items={modules}
+        emptyItem={EMPTY_MODULE}
+        title={courseName}
+        subTitle="Hantera moduler"
+        buttonLabel="Skapa ny modul"
+        FormComponent={FormComponent}
+        TableComponent={TableComponent}
+      />
+    </Stack>
   );
 };
 export default AdminModulesPage;

--- a/Frontend/src/pages/ModulePage.tsx
+++ b/Frontend/src/pages/ModulePage.tsx
@@ -7,6 +7,7 @@ import theme from '../styles/theme';
 import { IActivity, IModule } from '../utilities/types';
 import { formatDate, sortByDate } from '../utilities/helpers';
 import Date from '../components/Date';
+import BackLink from '../components/BackLink';
 
 const ModulePage = (): ReactElement => {
   const { module, activities } = useLoaderData();
@@ -16,18 +17,21 @@ const ModulePage = (): ReactElement => {
       <Suspense>
         <Await resolve={module}>
           {(module: IModule) => (
-            <Card title={module.name} titleVariant="h1">
-              <Typography mb={theme.layout.gap}>{module.description}</Typography>
-              <Stack direction="row" spacing={theme.spacing(6)} alignItems="center">
-                <Typography variant="body2">
-                  Del av kurs:{' '}
-                  <Typography component="span" fontWeight="bold">
-                    {module.courseName}
+            <>
+              <BackLink name={module.courseName} />
+              <Card title={module.name} titleVariant="h1">
+                <Typography mb={theme.layout.gap}>{module.description}</Typography>
+                <Stack direction="row" spacing={theme.spacing(6)} alignItems="center">
+                  <Typography variant="body2">
+                    Del av kurs:{' '}
+                    <Typography component="span" fontWeight="bold">
+                      {module.courseName}
+                    </Typography>
                   </Typography>
-                </Typography>
-                <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
-              </Stack>
-            </Card>
+                  <Date start={formatDate(module.startDate)} end={formatDate(module.endDate)} />
+                </Stack>
+              </Card>
+            </>
           )}
         </Await>
       </Suspense>


### PR DESCRIPTION
**Reason for change**

Adding link to go backwards in nested pages.
[Frontend: Create back link #209](https://github.com/lexicon-team-steel/learning-management-system/issues/209)

**Changes**

- Added component with button that looks lika a link and navigates one step back.
- Implemented component in ModulesPage, AdminModulesPage and AdminActivitiesPage.

**How to test**

1. Start the project and log in.
2. Navigate to a module page and there should be a link at the top on a modules page that takes you back to the course page.
3. Navigate through the admin pages and on the modules and on the activities pages there should also be links that will navigate you backwards.
